### PR TITLE
Implement basic roster panel script

### DIFF
--- a/Gridiron GM Alpha Build/Assets/Scripts/DashboardUI.cs
+++ b/Gridiron GM Alpha Build/Assets/Scripts/DashboardUI.cs
@@ -9,6 +9,8 @@ public class DashboardUI : MonoBehaviour
     public Text phaseText;
     public Text opponentText;
     public Text recordText;
+    public GameObject dashboardPanel;
+    public GameObject rosterPanel;
 
     void Start()
     {
@@ -27,7 +29,10 @@ public class DashboardUI : MonoBehaviour
 
     public void OnViewRosterPressed()
     {
-        Debug.Log("View Roster pressed");
+        if (dashboardPanel != null)
+            dashboardPanel.SetActive(false);
+        if (rosterPanel != null)
+            rosterPanel.SetActive(true);
     }
 
     public void OnViewDepthChartPressed()

--- a/Gridiron GM Alpha Build/Assets/Scripts/RosterUI.cs
+++ b/Gridiron GM Alpha Build/Assets/Scripts/RosterUI.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Collections.Generic;
+
+public class RosterUI : MonoBehaviour
+{
+    public GameObject playerRowPrefab; // Assign in inspector
+    public Transform contentParent;    // ScrollView Content parent
+    public GameObject dashboardPanel;
+    public GameObject rosterPanel;
+
+    void OnEnable()
+    {
+        PopulateFakeRoster();
+    }
+
+    void PopulateFakeRoster()
+    {
+        foreach (Transform child in contentParent)
+        {
+            Destroy(child.gameObject);
+        }
+
+        List<Player> fakePlayers = new List<Player>
+        {
+            new Player("QB", "J. Allen", 92),
+            new Player("RB", "D. Cook", 85),
+            new Player("WR", "S. Diggs", 90),
+            new Player("LT", "T. Dawkins", 83),
+            new Player("CB", "T. White", 88),
+        };
+
+        foreach (var p in fakePlayers)
+        {
+            GameObject row = Instantiate(playerRowPrefab, contentParent);
+            row.transform.Find("PositionText").GetComponent<Text>().text = p.position;
+            row.transform.Find("NameText").GetComponent<Text>().text = p.name;
+            row.transform.Find("OverallText").GetComponent<Text>().text = $"OVR: {p.overall}";
+        }
+    }
+
+    public void OnBackPressed()
+    {
+        rosterPanel.SetActive(false);
+        dashboardPanel.SetActive(true);
+    }
+
+    private class Player
+    {
+        public string position;
+        public string name;
+        public int overall;
+
+        public Player(string pos, string name, int ovr)
+        {
+            this.position = pos;
+            this.name = name;
+            this.overall = ovr;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RosterUI` to populate a simple roster list
- allow `DashboardUI` to toggle between dashboard and roster panels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851adb5b1908327a535b409917814f0