### PR TITLE
Add schedule UI panel support

### DIFF
--- a/Gridiron GM Alpha Build/Assets/Scripts/DashboardUI.cs
+++ b/Gridiron GM Alpha Build/Assets/Scripts/DashboardUI.cs
@@ -11,6 +11,7 @@ public class DashboardUI : MonoBehaviour
     public Text recordText;
     public GameObject dashboardPanel;
     public GameObject rosterPanel;
+    public GameObject schedulePanel;
 
     void Start()
     {
@@ -42,7 +43,10 @@ public class DashboardUI : MonoBehaviour
 
     public void OnViewSchedulePressed()
     {
-        Debug.Log("View Schedule pressed");
+        if (dashboardPanel != null)
+            dashboardPanel.SetActive(false);
+        if (schedulePanel != null)
+            schedulePanel.SetActive(true);
     }
 
     public void OnSimWeekPressed()

--- a/Gridiron GM Alpha Build/Assets/Scripts/ScheduleUI.cs
+++ b/Gridiron GM Alpha Build/Assets/Scripts/ScheduleUI.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Collections.Generic;
+
+public class ScheduleUI : MonoBehaviour
+{
+    public GameObject weekRowPrefab;
+    public Transform contentParent;
+    public GameObject schedulePanel;
+    public GameObject dashboardPanel;
+
+    void OnEnable()
+    {
+        PopulateFakeSchedule();
+    }
+
+    void PopulateFakeSchedule()
+    {
+        foreach (Transform child in contentParent)
+        {
+            Destroy(child.gameObject);
+        }
+
+        List<string> fakeSchedule = new List<string>
+        {
+            "Week 1: vs TBD",
+            "Week 2: @ TBD",
+            "Week 3: vs TBD",
+            "Week 4: @ TBD",
+            "Week 5: vs TBD",
+            "Week 6: @ TBD",
+            "Week 7: vs TBD",
+            "Week 8: @ TBD",
+            "Week 9: vs TBD",
+            "Week 10: @ TBD"
+        };
+
+        foreach (string week in fakeSchedule)
+        {
+            GameObject row = Instantiate(weekRowPrefab, contentParent);
+            row.transform.Find("WeekText").GetComponent<Text>().text = week;
+        }
+    }
+
+    public void OnSimWeekPressed()
+    {
+        Debug.Log("Sim Week clicked (future logic)");
+    }
+
+    public void OnBackPressed()
+    {
+        schedulePanel.SetActive(false);
+        dashboardPanel.SetActive(true);
+    }
+}

--- a/Gridiron GM Alpha Build/Assets/Scripts/ScheduleUI.cs.meta
+++ b/Gridiron GM Alpha Build/Assets/Scripts/ScheduleUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c0fc578d915444f095885a4908325f8c


### PR DESCRIPTION
## Summary
- create `ScheduleUI` script for weekly schedule scroll list
- create meta file for new script
- allow DashboardUI to toggle the schedule panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851aec86c5c832786b29b321291dd6d