### PR TITLE
Add dynamic team selection UI scripts

### DIFF
--- a/Assets/Scripts/TeamRowUI.cs
+++ b/Assets/Scripts/TeamRowUI.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using UnityEngine.EventSystems;
+
+public class TeamRowUI : MonoBehaviour, IPointerClickHandler
+{
+    public Image logoImage;
+    public TMP_Text nameText;
+    public TMP_Text conferenceText;
+
+    public string teamAbbreviation;
+    public System.Action OnRowClicked;
+
+    public void SetData(TeamData data)
+    {
+        if (data == null) return;
+        if (logoImage != null) logoImage.sprite = data.logo;
+        if (nameText != null) nameText.text = data.teamName;
+        if (conferenceText != null) conferenceText.text = data.conference;
+        teamAbbreviation = data.abbreviation;
+    }
+
+    public void OnPointerClick(PointerEventData eventData)
+    {
+        OnRowClicked?.Invoke();
+    }
+}

--- a/Assets/Scripts/TeamRowUI.cs.meta
+++ b/Assets/Scripts/TeamRowUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 177864d220184ba384365d2900be5589

--- a/Assets/Scripts/TeamSelectionUI.cs
+++ b/Assets/Scripts/TeamSelectionUI.cs
@@ -1,24 +1,55 @@
+using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using TMPro;
+
+[System.Serializable]
+public class TeamData
+{
+    public string abbreviation;
+    public string teamName;
+    public string conference;
+    public Sprite logo;
+}
 
 public class TeamSelectionUI : MonoBehaviour
 {
-    private string selectedTeam = "";
-
+    public GameObject teamRowPrefab;         // Assign the prefab from UI
+    public Transform teamRowParent;          // Assign the Content object from ScrollView
     public Button confirmButton;
 
-    private void Start()
+    public List<TeamData> allTeams;          // Populate in Inspector or from JSON later
+
+    private string selectedTeam = "";
+
+    void Start()
     {
         if (confirmButton != null)
         {
             confirmButton.interactable = false;
         }
+        GenerateTeamRows();
     }
 
-    public void OnTeamButtonPressed(string teamAbbreviation)
+    void GenerateTeamRows()
     {
-        selectedTeam = teamAbbreviation;
+        if (teamRowPrefab == null || teamRowParent == null) return;
+
+        foreach (var team in allTeams)
+        {
+            GameObject row = Instantiate(teamRowPrefab, teamRowParent);
+            TeamRowUI rowUI = row.GetComponent<TeamRowUI>();
+            if (rowUI != null)
+            {
+                rowUI.SetData(team);
+                rowUI.OnRowClicked = () => OnTeamSelected(team);
+            }
+        }
+    }
+
+    void OnTeamSelected(TeamData team)
+    {
+        selectedTeam = team.abbreviation;
         Debug.Log("Selected Team: " + selectedTeam);
         if (confirmButton != null)
         {
@@ -28,18 +59,14 @@ public class TeamSelectionUI : MonoBehaviour
 
     public void OnConfirmPressed()
     {
-        if (string.IsNullOrEmpty(selectedTeam))
-        {
-            Debug.Log("No team selected.");
-            return;
-        }
+        if (string.IsNullOrEmpty(selectedTeam)) return;
 
         PlayerPrefs.SetString("selected_team", selectedTeam);
-        SceneManager.LoadScene("GameWorld");
+        UnityEngine.SceneManagement.SceneManager.LoadScene("GameWorld");
     }
 
     public void OnBackPressed()
     {
-        SceneManager.LoadScene("NewGameSetup");
+        UnityEngine.SceneManagement.SceneManager.LoadScene("NewGameSetup");
     }
 }


### PR DESCRIPTION
## Summary
- overhaul TeamSelectionUI script to dynamically create rows from a team list
- add TeamRowUI component for interactive team rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853105d4e5883278b4447859c2272fe