### PR TITLE
Create TeamDataUI model and cleanup UI scripts

### DIFF
--- a/Assets/Scripts/TeamDataUI.cs
+++ b/Assets/Scripts/TeamDataUI.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+[System.Serializable]
+public class TeamDataUI
+{
+    public string teamName;
+    public string conference;
+    public string abbreviation;
+    public Sprite logo;
+
+    public TeamDataUI(string teamName, string conference, string abbreviation, Sprite logo)
+    {
+        this.teamName = teamName;
+        this.conference = conference;
+        this.abbreviation = abbreviation;
+        this.logo = logo;
+    }
+}

--- a/Assets/Scripts/TeamDataUI.cs.meta
+++ b/Assets/Scripts/TeamDataUI.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fbf6f5bfb5c9b2931d0b3b6902ed20cc
+

--- a/Assets/Scripts/TeamSelectionUI.cs
+++ b/Assets/Scripts/TeamSelectionUI.cs
@@ -1,34 +1,12 @@
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
+using UnityEngine.SceneManagement;
 
 // This script dynamically loads team data from teams.json, instantiates a
 // TeamRowUI prefab for each team, wires up click events, and tracks the
 // selected team for the next scene.
 
-[System.Serializable]
-public class TeamJson
-{
-    public string city;
-    public string name;
-    public string abbreviation;
-    public string conference;
-}
-
-[System.Serializable]
-public class TeamDataList
-{
-    public List<TeamJson> teams;
-}
-
-[System.Serializable]
-public class TeamData
-{
-    public string abbreviation;
-    public string teamName;
-    public string conference;
-    public Sprite logo;
-}
 
 public class TeamSelectionUI : MonoBehaviour
 {
@@ -67,13 +45,12 @@ public class TeamSelectionUI : MonoBehaviour
             if (ui == null) continue;
 
             Sprite logo = Resources.Load<Sprite>($"teamsprites/{team.abbreviation}");
-            TeamData uiData = new TeamData
-            {
-                teamName = $"{team.city} {team.name}",
-                conference = team.conference,
-                abbreviation = team.abbreviation,
-                logo = logo
-            };
+            TeamDataUI uiData = new TeamDataUI(
+                $"{team.city} {team.name}",
+                team.conference,
+                team.abbreviation,
+                logo
+            );
             ui.SetData(uiData);
 
             ui.OnRowClicked = () =>


### PR DESCRIPTION
## Summary
- add TeamDataUI.cs class for UI friendly team data
- remove inline data classes in TeamSelectionUI and use TeamDataUI
- update SetData in TeamRowUI to rely on new model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853199880848327b4ee2514173b1902