### PR TITLE
Fix TeamRowUI data type and logging

### DIFF
--- a/Assets/Scripts/TeamRowUI.cs
+++ b/Assets/Scripts/TeamRowUI.cs
@@ -12,27 +12,54 @@ public class TeamRowUI : MonoBehaviour, IPointerClickHandler
     public string teamAbbreviation;
     public System.Action OnRowClicked;
 
-    // Make sure to define TeamDataUI in your project, for example:
-    public class TeamDataUI
-    {
-        // Example fields for TeamDataUI
-        public Sprite logo;
-        public string teamName;
-        public string teamConference;
-        public string abbreviation;
-    }
+    // Data for populating the row. Defined in TeamDataUI.cs
 
     public void SetData(TeamDataUI data)
     {
-        if (data == null) return;
-        if (logoImage != null) logoImage.sprite = data.logo;
-        if (nameText != null) nameText.text = data.teamName;
-        if (conferenceText != null) conferenceText.text = data.teamConference;
+        if (data == null)
+        {
+            Debug.LogWarning("TeamRowUI.SetData called with null data!");
+            return;
+        }
+
+        Debug.Log($"Applying Team Data: {data.teamName}, {data.teamConference}, {data.abbreviation}");
+
+        if (logoImage != null)
+        {
+            logoImage.sprite = data.logo;
+            Debug.Log($"Logo assigned: {data.logo}");
+        }
+        else
+        {
+            Debug.LogWarning("Logo Image reference is missing on TeamRowUI.");
+        }
+
+        if (nameText != null)
+        {
+            nameText.text = data.teamName;
+            Debug.Log($"Name text set: {data.teamName}");
+        }
+        else
+        {
+            Debug.LogWarning("Name Text reference is missing on TeamRowUI.");
+        }
+
+        if (conferenceText != null)
+        {
+            conferenceText.text = data.teamConference;
+            Debug.Log($"Conference text set: {data.teamConference}");
+        }
+        else
+        {
+            Debug.LogWarning("Conference Text reference is missing on TeamRowUI.");
+        }
+
         teamAbbreviation = data.abbreviation;
     }
 
     public void OnPointerClick(PointerEventData eventData)
     {
+        Debug.Log($"TeamRowUI clicked: {teamAbbreviation}");
         OnRowClicked?.Invoke();
     }
 }

--- a/Assets/Scripts/TeamSelectionUI.cs
+++ b/Assets/Scripts/TeamSelectionUI.cs
@@ -62,7 +62,7 @@ public class TeamSelectionUI : MonoBehaviour
             if (ui == null) continue;
 
             Sprite logo = Resources.Load<Sprite>($"teamsprites/{team.abbreviation}");
-            TeamRowUI.TeamDataUI uiData = new TeamRowUI.TeamDataUI
+            TeamDataUI uiData = new TeamDataUI
             {
                 teamName = $"{team.city} {team.name}",
                 teamConference = team.conference,


### PR DESCRIPTION
## Summary
- reference the standalone `TeamDataUI` class instead of nested class in `TeamRowUI`
- add detailed debug logging inside `TeamRowUI.SetData`
- update `OnPointerClick` to log the clicked team
- update `TeamSelectionUI` to pass the standalone `TeamDataUI`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855b1822bfc8327b046dbf8028fa7d0