### PR TITLE
Implement roster bootstrap and team selection persistence

### DIFF
--- a/Assets/Scripts/Data/RosterBootstrapper.cs
+++ b/Assets/Scripts/Data/RosterBootstrapper.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+using GridironGM.Data;
+using Newtonsoft.Json;
+
+namespace GridironGM.Boot
+{
+    /// Ensures rosters_by_team.json includes ALL teams from teams.json.
+    /// If the file is missing or a team key is missing/empty, we create placeholders.
+    public static class RosterBootstrapper
+    {
+        private const string TeamsFile   = "teams.json";
+        private const string RostersFile = "rosters_by_team.json";
+
+        public static void EnsureRostersExist(int playersPerTeam = 12)
+        {
+            string streaming   = Application.streamingAssetsPath;
+            string teamsPath   = Path.Combine(streaming, TeamsFile);
+            string rostersPath = Path.Combine(streaming, RostersFile);
+
+            if (!File.Exists(teamsPath))
+            {
+                Debug.LogError($"[RosterBootstrapper] Missing {TeamsFile} in StreamingAssets.");
+                return;
+            }
+
+            List<TeamData> teams;
+            try { teams = JsonLoader.LoadFromStreamingAssets<List<TeamData>>(TeamsFile); }
+            catch (Exception ex) { Debug.LogError($"[RosterBootstrapper] Load teams.json failed: {ex.Message}"); return; }
+            if (teams == null || teams.Count == 0) { Debug.LogError("[RosterBootstrapper] teams.json empty."); return; }
+
+            // Load existing rosters if present; otherwise start fresh.
+            RosterByTeam rosters = null;
+            if (File.Exists(rostersPath))
+            {
+                try
+                {
+                    var text = File.ReadAllText(rostersPath);
+                    rosters = string.IsNullOrWhiteSpace(text) ? null : JsonConvert.DeserializeObject<RosterByTeam>(text);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogWarning($"[RosterBootstrapper] Existing rosters unreadable. Will regenerate. {ex.Message}");
+                }
+            }
+            rosters ??= new RosterByTeam();
+
+            var rng = new System.Random(1337);
+            int filled = 0;
+
+            foreach (var t in teams)
+            {
+                if (!rosters.TryGetValue(t.abbreviation, out var list) || list == null || list.Count == 0)
+                {
+                    rosters[t.abbreviation] = MakePlaceholder(playersPerTeam, rng);
+                    filled++;
+                }
+            }
+
+            if (filled > 0 || !File.Exists(rostersPath))
+            {
+                try
+                {
+                    var json = JsonConvert.SerializeObject(rosters, Formatting.Indented);
+                    File.WriteAllText(rostersPath, json);
+                    Debug.Log($"[RosterBootstrapper] Filled {filled} missing teams. Total: {rosters.Count}.");
+                }
+                catch (Exception ex) { Debug.LogError($"[RosterBootstrapper] Write rosters failed: {ex.Message}"); }
+            }
+            else
+            {
+                Debug.Log($"[RosterBootstrapper] Found existing rosters for {rosters.Count} teams.");
+            }
+        }
+
+        private static List<PlayerData> MakePlaceholder(int n, System.Random rng)
+        {
+            var list = new List<PlayerData>(Mathf.Max(n, 1));
+            for (int i = 0; i < n; i++)
+            {
+                var pos = PickPos(i);
+                int baseOvr = BaseOvrFor(pos);
+                int ovr = Mathf.Clamp(baseOvr + rng.Next(-5, 6), 60, 92);
+                int age = Mathf.Clamp(22 + rng.Next(0, 13), 20, 35);
+
+                list.Add(new PlayerData
+                {
+                    id    = i + 1,
+                    first = Firsts[rng.Next(Firsts.Length)],
+                    last  = Lasts[rng.Next(Lasts.Length)],
+                    pos   = pos,
+                    ovr   = ovr,
+                    age   = age
+                });
+            }
+            return list;
+        }
+
+        private static string PickPos(int i)
+        {
+            string[] order = { "QB","RB","WR","WR","TE","OL","DL","LB","CB","S","K","P" };
+            return order[i % order.Length];
+        }
+        private static int BaseOvrFor(string pos) =>
+            pos switch { "QB"=>78, "WR"=>76, "RB"=>74, "CB"=>74, "TE"=>72, _=>70 };
+
+        private static readonly string[] Firsts = { "Alex","Chris","Jordan","Taylor","Casey","Jalen","Devin","Micah" };
+        private static readonly string[] Lasts  = { "Smith","Johnson","Brown","Williams","Jones","Davis","Miller","Moore" };
+    }
+}

--- a/Assets/Scripts/Data/RosterBootstrapper.cs.meta
+++ b/Assets/Scripts/Data/RosterBootstrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 711a0b509c604da18fd5e27e3283d68f

--- a/Assets/Scripts/GameState.cs
+++ b/Assets/Scripts/GameState.cs
@@ -2,20 +2,33 @@ using UnityEngine;
 
 namespace GridironGM
 {
+    // Simple global state that auto-creates itself if needed and persists across scenes.
     public class GameState : MonoBehaviour
     {
-        public static GameState Instance { get; private set; }
+        private static GameState _instance;
+        public static GameState Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    var go = new GameObject("GameState");
+                    _instance = go.AddComponent<GameState>();
+                }
+                return _instance;
+            }
+        }
 
-        public string SelectedTeamAbbr { get; set; }
+        public string SelectedTeamAbbr { get; set; } = "";
 
         private void Awake()
         {
-            if (Instance != null && Instance != this)
+            if (_instance != null && _instance != this)
             {
                 Destroy(gameObject);
                 return;
             }
-            Instance = this;
+            _instance = this;
             DontDestroyOnLoad(gameObject);
         }
     }

--- a/Assets/Scripts/UI/TeamSelection/PlayerRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/PlayerRowUI.cs
@@ -1,5 +1,5 @@
-using UnityEngine;
 using TMPro;
+using UnityEngine;
 
 namespace GridironGM.UI.TeamSelection
 {
@@ -26,12 +26,16 @@ namespace GridironGM.UI.TeamSelection
             if (!nameText) nameText = transform.Find("NameText")?.GetComponent<TMP_Text>();
             if (!posText)  posText  = transform.Find("PosText")?.GetComponent<TMP_Text>();
             if (!ovrText)  ovrText  = transform.Find("OvrText")?.GetComponent<TMP_Text>();
-            if (!ageText)  ageText  = transform.Find("AgeText")?.GetComponent<TMP_Text>();
+            if (!ageText)
+            {
+                ageText = transform.Find("AgeText")?.GetComponent<TMP_Text>();
+                if (!ageText) ageText = transform.Find("NumText")?.GetComponent<TMP_Text>(); // support your earlier naming
+            }
         }
 
-        private void Awake()     => TryAutoWire();
+        private void Awake() { TryAutoWire(); }
 #if UNITY_EDITOR
-        private void OnValidate() => TryAutoWire();
+        private void OnValidate() { TryAutoWire(); }
 #endif
     }
 }

--- a/Assets/Scripts/UI/TeamSelection/RosterPanelUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/RosterPanelUI.cs
@@ -1,62 +1,69 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using UnityEngine;
 using Debug = UnityEngine.Debug;
+using UnityEngine.UI;
+using GridironGM.Data;
 
 namespace GridironGM.UI.TeamSelection
 {
     public class RosterPanelUI : MonoBehaviour
     {
         [Header("Wiring")]
-        [SerializeField] private Transform content;            // ScrollView Content
-        [SerializeField] private GameObject playerRowPrefab;   // Prefab with PlayerRowUI
-        [SerializeField] private TMP_Text messageText;         // Optional "No data" label
+        [SerializeField] private Transform content;          // ScrollView Content
+        [SerializeField] private GameObject playerRowPrefab; // Prefab with PlayerRowUI
+        [SerializeField] private TMP_Text messageText;       // Optional "No data" label
 
-        [Header("Behavior")]
-        [SerializeField] private bool loadSelectedOnEnable = false;
-
-        private Dictionary<string, List<GridironGM.Data.PlayerData>> rosters;
+        private RosterByTeam rosters;
 
         private void Awake()
         {
             TryAutoWire();
-            LoadRostersOnce();
+            ReloadRosters(); // load whatever exists at startup
         }
 
-        private void OnEnable()
+        public void ReloadRosters()
         {
-            if (loadSelectedOnEnable && GridironGM.GameState.Instance != null)
+            try
             {
-                var abbr = GridironGM.GameState.Instance.SelectedTeamAbbr;
-                if (!string.IsNullOrEmpty(abbr))
-                    ShowRosterForTeam(abbr);
+                rosters = JsonLoader.LoadFromStreamingAssets<RosterByTeam>("rosters_by_team.json");
+                Debug.Log($"[RosterPanelUI] Reloaded roster map for {(rosters?.Count ?? 0)} teams.");
+            }
+            catch (Exception ex)
+            {
+                rosters = null;
+                Debug.LogError($"[RosterPanelUI] Failed to load rosters: {ex.Message}");
             }
         }
 
         public void ShowRosterForTeam(string abbr)
         {
-            if (content == null || playerRowPrefab == null)
+            if (!content || !playerRowPrefab)
             {
-                Debug.LogError("[RosterPanelUI] Missing content or playerRowPrefab.");
+                Debug.LogError("[RosterPanelUI] Missing Content or Player Row Prefab.");
                 return;
             }
+
+            // In case the file was generated after Awake()
+            if (rosters == null || rosters.Count == 0)
+                ReloadRosters();
 
             // Clear old rows
             for (int i = content.childCount - 1; i >= 0; i--)
                 Destroy(content.GetChild(i).gameObject);
 
+            if (messageText) messageText.text = "";
+
             if (rosters == null || !rosters.TryGetValue(abbr, out var list) || list == null || list.Count == 0)
             {
                 if (messageText) messageText.text = $"No roster data for {abbr}";
+                Debug.LogWarning($"[RosterPanelUI] No roster for {abbr}.");
                 return;
             }
 
-            if (messageText) messageText.text = "";
-
-            foreach (var p in list
-                .OrderBy(pl => pl.pos)
-                .ThenByDescending(pl => pl.ovr))
+            foreach (var p in list.OrderBy(pl => pl.pos).ThenByDescending(pl => pl.ovr))
             {
                 var go = Instantiate(playerRowPrefab, content);
                 var row = go.GetComponent<PlayerRowUI>();
@@ -71,36 +78,17 @@ namespace GridironGM.UI.TeamSelection
             Debug.Log($"[RosterPanelUI] Rendered {list.Count} players for {abbr}.");
         }
 
-        private void LoadRostersOnce()
-        {
-            if (rosters != null) return;
-
-            try
-            {
-                // Expecting GridironGM.Data.RosterByTeam : Dictionary<string, List<PlayerData>>
-                rosters = GridironGM.Data.JsonLoader.LoadFromStreamingAssets<GridironGM.Data.RosterByTeam>("rosters_by_team.json");
-                if (rosters == null)
-                    Debug.LogWarning("[RosterPanelUI] rosters_by_team.json not found or empty.");
-                else
-                    Debug.Log($"[RosterPanelUI] Loaded roster map for {rosters.Count} teams.");
-            }
-            catch (System.SystemException ex)
-            {
-                Debug.LogError($"[RosterPanelUI] Failed to load rosters: {ex.Message}");
-            }
-        }
-
         private void TryAutoWire()
         {
             if (!content)
             {
-                var tf = transform.Find("Viewport/Content") ?? transform.Find("Content");
-                if (tf) content = tf;
-            }
-            if (!messageText)
-            {
-                var msg = transform.Find("MessageText")?.GetComponent<TMP_Text>();
-                if (msg) messageText = msg;
+                var sr = GetComponent<ScrollRect>() ?? GetComponentInChildren<ScrollRect>(true);
+                if (sr && sr.content) content = sr.content;
+                if (!content)
+                {
+                    var tf = transform.Find("Viewport/Content") ?? transform.Find("ScrollView/Viewport/Content") ?? transform.Find("Content");
+                    if (tf) content = tf;
+                }
             }
         }
     }

--- a/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
@@ -12,60 +12,30 @@ namespace GridironGM.UI.TeamSelection
         [SerializeField] private Image logoImage;
 
         private string abbr;
-        private Button _button;
-        private void Awake()
-        {
-            // Auto-wire if not set
-            if (!nameText) nameText = transform.Find("NameText")?.GetComponent<TMP_Text>();
-            if (!conferenceText) conferenceText = transform.Find("ConferenceText")?.GetComponent<TMP_Text>();
-            if (!logoImage) logoImage = transform.Find("LogoImage")?.GetComponent<Image>();
-
-            // Ensure button is present
-            _button = GetComponent<Button>() ?? GetComponentInChildren<Button>(true);
-            if (_button == null)
-            {
-                Debug.LogError("[TeamRowUI] Button component missing on prefab/root. Add a Button + Image with Raycast Target ON.");
-            }
-        }
-
 
         public void Set(GridironGM.Data.TeamData data, System.Action onClick)
         {
             abbr = data.abbreviation;
-            if (nameText) nameText.text = $"{data.city} {data.name}";
+            if (nameText)       nameText.text = $"{data.city} {data.name}";
             if (conferenceText) conferenceText.text = data.conference;
 
-            var sprite = Resources.Load<Sprite>($"TeamSprites/{abbr}");
-            if (!sprite)
-            {
-                Debug.LogWarning($"[TeamRowUI] Missing sprite for {abbr}. Using fallback if available.");
-                sprite = Resources.Load<Sprite>("TeamSprites/Generic");
-            }
+            var sprite = Resources.Load<Sprite>($"TeamSprites/{abbr}") ?? Resources.Load<Sprite>("TeamSprites/Generic");
             if (logoImage)
             {
-                logoImage.sprite = sprite;
+                logoImage.sprite  = sprite;
                 logoImage.enabled = sprite != null;
             }
 
-            // --- CLICK HOOKUP (robust) ---
+            // Robust button hookup
             var btn = GetComponent<Button>() ?? GetComponentInChildren<Button>(true);
-            if (btn == null)
+            if (!btn)
             {
-                Debug.LogError("[TeamRowUI] Button component missing on prefab/root. Add a Button + Image with Raycast Target ON.");
-                return;
-            }
-
-            if (onClick == null)
-            {
-                Debug.LogError("[TeamRowUI] onClick callback is null. TeamSelectionUI must pass a handler.");
-                btn.onClick.RemoveAllListeners(); // prevent stale listeners
+                Debug.LogError("[TeamRowUI] Button missing on prefab. Add Image (Raycast ON) + Button on root.");
                 return;
             }
 
             btn.onClick.RemoveAllListeners();
-            btn.onClick.AddListener(() => onClick());
-            // Optional: quick proof in Console
-            // Debug.Log($"[TeamRowUI] Hooked click for {abbr}");
-        }
+            if (onClick != null) btn.onClick.AddListener(() => onClick());
         }
     }
+}

--- a/Assets/Scripts/UI/TeamSelection/TeamSelectionUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamSelectionUI.cs
@@ -1,83 +1,110 @@
 using System.Collections.Generic;
 using System.Linq;
-using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
-using GridironGM;
-using GridironGM.Data;
-using GridironGM.UI.TeamSelection;
+using Debug = UnityEngine.Debug;
 
-namespace GridironGM.UI
+namespace GridironGM.UI.TeamSelection
 {
     public class TeamSelectionUI : MonoBehaviour
     {
-        [SerializeField] private Transform teamListContent;
-        [SerializeField] private TeamRowUI teamRowPrefab;
-        [SerializeField] private Button confirmButton;
-        [SerializeField] private TMP_Text errorText;
-        [SerializeField] private RosterPanelUI rosterPanel;
+        [Header("Left list")]
+        [SerializeField] private Transform teamListContent;   // LeftPanel/Viewport/Content
+        [SerializeField] private GameObject teamRowPrefab;    // TeamRowUI prefab
+
+        [Header("Right panel")]
+        [SerializeField] private RosterPanelUI rosterPanel;   // RightPanel has this
+
+        [Header("Flow")]
+        [SerializeField] private Button confirmButton;        // bottom confirm button (optional)
+
+        private List<GridironGM.Data.TeamData> teams;
+
+        private void Awake()
+        {
+            if (confirmButton) confirmButton.interactable = false;
+        }
 
         private void Start()
         {
-            if (confirmButton != null)
-            {
-                confirmButton.interactable = false;
-            }
-            if (errorText != null)
-            {
-                errorText.gameObject.SetActive(false);
-            }
+            // 1) Ensure data exists
+            GridironGM.Boot.RosterBootstrapper.EnsureRostersExist(playersPerTeam: 12);
 
-            List<TeamData> teams = JsonLoader.LoadFromStreamingAssets<List<TeamData>>("teams.json");
+            // 2) Reload panel’s in-memory data (it may have loaded too early in Awake)
+            if (rosterPanel) rosterPanel.ReloadRosters();
+
+            TryAutoWire();
+
+            teams = GridironGM.Data.JsonLoader
+                .LoadFromStreamingAssets<List<GridironGM.Data.TeamData>>("teams.json");
+
             if (teams == null || teams.Count == 0)
             {
-                Debug.LogError("teams.json missing or empty");
-                ShowError("Failed to load team data");
+                Debug.LogError("[TeamSelectionUI] teams.json missing or empty.");
                 return;
             }
 
-            Debug.Log($"Loaded {teams.Count} teams");
+            foreach (var t in teams.OrderBy(t => (t.city + " " + t.name)))
+                AddTeamRow(t);
 
-            foreach (Transform child in teamListContent)
-            {
-                Destroy(child.gameObject);
-            }
-
-            foreach (TeamData team in teams.OrderBy(t => t.city).ThenBy(t => t.name))
-            {
-                TeamRowUI row = Instantiate(teamRowPrefab, teamListContent);
-                row.Set(team, () => OnTeamClicked(team));
-            }
+            Debug.Log($"[TeamSelectionUI] Spawned {teams.Count} teams.");
         }
 
-        private void OnTeamClicked(TeamData team)
+        private void AddTeamRow(GridironGM.Data.TeamData t)
         {
-            GameState.Instance.SelectedTeamAbbr = team.abbreviation;
-            Debug.Log($"Team clicked: {team.abbreviation}");
-            if (confirmButton != null)
+            if (!teamListContent || !teamRowPrefab)
             {
-                confirmButton.interactable = true;
+                Debug.LogError("[TeamSelectionUI] teamListContent or teamRowPrefab not assigned.");
+                return;
             }
-            rosterPanel?.ShowRosterForTeam(team.abbreviation);
+
+            var go  = Instantiate(teamRowPrefab, teamListContent);
+            var row = go.GetComponent<TeamRowUI>();
+            if (!row)
+            {
+                Debug.LogError("[TeamSelectionUI] TeamRowUI missing on teamRowPrefab.");
+                return;
+            }
+
+            row.Set(t, () => OnTeamClicked(t));
+        }
+
+        private void OnTeamClicked(GridironGM.Data.TeamData team)
+        {
+            if (team == null) { Debug.LogError("[TeamSelectionUI] Null team"); return; }
+
+            // Save selection if GameState exists (or will autospawn)
+            GridironGM.GameState.Instance.SelectedTeamAbbr = team.abbreviation;
+
+            if (confirmButton) confirmButton.interactable = true;
+            if (rosterPanel)   rosterPanel.ShowRosterForTeam(team.abbreviation);
+
+            Debug.Log($"[TeamSelectionUI] Selected {team.abbreviation}");
         }
 
         public void OnConfirm()
         {
-            SceneManager.LoadScene("NewGameSetup");
+            var abbr = GridironGM.GameState.Instance?.SelectedTeamAbbr;
+            if (string.IsNullOrEmpty(abbr))
+            {
+                Debug.LogWarning("[TeamSelectionUI] No team selected.");
+                return;
+            }
+
+            SceneManager.LoadScene("NewGameSetup"); // adjust as needed
         }
 
-        private void ShowError(string message)
+        private void TryAutoWire()
         {
-            if (errorText != null)
+            if (!teamListContent)
             {
-                errorText.text = message;
-                errorText.gameObject.SetActive(true);
+                var tf = transform.root.Find("Canvas/LeftPanel/Viewport/Content");
+                if (!tf) tf = GameObject.Find("LeftPanel/Viewport/Content")?.transform;
+                teamListContent = tf;
             }
-            if (confirmButton != null)
-            {
-                confirmButton.interactable = false;
-            }
+            if (!rosterPanel)
+                rosterPanel = FindObjectOfType<RosterPanelUI>(true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Autogenerate rosters_by_team.json on scene start with new RosterBootstrapper
- Reload roster data before display and make team rows clickable
- Persist selected team across scenes via GameState

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68996b12dc188327b1a3eca61008dbb7