### PR TITLE
Improve team selection roster panel population

### DIFF
--- a/Assets/Scripts/UI/TeamSelection/PlayerRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/PlayerRowUI.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using TMPro;
 using UnityEngine;
+using Debug = UnityEngine.Debug;
 
 namespace GridironGM.UI.TeamSelection
 {
@@ -13,29 +15,53 @@ namespace GridironGM.UI.TeamSelection
         public void Set(GridironGM.Data.PlayerData p)
         {
             if (p == null) { gameObject.SetActive(false); return; }
-            if (!nameText || !posText || !ovrText) TryAutoWire();
 
-            if (nameText) nameText.text = $"{p.first} {p.last}";
-            if (posText)  posText.text  = p.pos;
-            if (ovrText)  ovrText.text  = p.ovr.ToString();
-            if (ageText)  ageText.text  = p.age > 0 ? p.age.ToString() : "";
+            // Try to auto-wire if fields are not set
+            if (!nameText || !posText || !ovrText)
+                TryAutoWireOrCreate();
+
+            if (!nameText || !posText || !ovrText)
+            {
+                Debug.LogError("[PlayerRowUI] Missing TMP fields even after auto-wire. Check prefab children or assign in Inspector.");
+                return;
+            }
+
+            nameText.text = $"{p.first} {p.last}";
+            posText.text  = p.pos;
+            ovrText.text  = p.ovr.ToString();
+            if (ageText) ageText.text = p.age > 0 ? p.age.ToString() : "";
         }
 
-        private void TryAutoWire()
+        private void TryAutoWireOrCreate()
         {
+            // 1) Try to find by expected names
             if (!nameText) nameText = transform.Find("NameText")?.GetComponent<TMP_Text>();
             if (!posText)  posText  = transform.Find("PosText")?.GetComponent<TMP_Text>();
             if (!ovrText)  ovrText  = transform.Find("OvrText")?.GetComponent<TMP_Text>();
             if (!ageText)
             {
                 ageText = transform.Find("AgeText")?.GetComponent<TMP_Text>();
-                if (!ageText) ageText = transform.Find("NumText")?.GetComponent<TMP_Text>(); // support your earlier naming
+                if (!ageText) ageText = transform.Find("NumText")?.GetComponent<TMP_Text>(); // support older naming
+            }
+
+            // 2) If still missing, grab any child TMPs in order: Name, Pos, Ovr, Age
+            if (!nameText || !posText || !ovrText)
+            {
+                var tmps = GetComponentsInChildren<TMP_Text>(true).ToList();
+                if (tmps.Count >= 3)
+                {
+                    if (!nameText) nameText = tmps[0];
+                    if (!posText)  posText  = tmps[1];
+                    if (!ovrText)  ovrText  = tmps[2];
+                    if (!ageText && tmps.Count >= 4) ageText = tmps[3];
+                }
             }
         }
 
-        private void Awake() { TryAutoWire(); }
+        private void Awake()     => TryAutoWireOrCreate();
 #if UNITY_EDITOR
-        private void OnValidate() { TryAutoWire(); }
+        private void OnValidate() => TryAutoWireOrCreate();
 #endif
     }
 }
+

--- a/Assets/Scripts/UI/TeamSelection/TeamSelectionUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamSelectionUI.cs
@@ -26,15 +26,10 @@ namespace GridironGM.UI.TeamSelection
             if (confirmButton) confirmButton.interactable = false;
         }
 
-        // (Remove duplicate declarations and keep only one set above)
-
-        [System.Obsolete]
         private void Start()
         {
-            // 1) Ensure data exists
+            // Ensure complete rosters, then refresh the panel's memory, THEN build left list
             GridironGM.Boot.RosterBootstrapper.EnsureRostersExist(playersPerTeam: 12);
-
-            // 2) Reload panel’s in-memory data (it may have loaded too early in Awake)
             if (rosterPanel) rosterPanel.ReloadRosters();
 
             TryAutoWire();
@@ -77,8 +72,6 @@ namespace GridironGM.UI.TeamSelection
         {
             if (team == null) { Debug.LogError("[TeamSelectionUI] Null team"); return; }
 
-
-            // Save selection if GameState exists (or will autospawn)
             GridironGM.GameState.Instance.SelectedTeamAbbr = team.abbreviation;
 
             if (confirmButton) confirmButton.interactable = true;
@@ -96,7 +89,7 @@ namespace GridironGM.UI.TeamSelection
                 return;
             }
 
-            SceneManager.LoadScene("NewGameSetup"); // adjust as needed
+            SceneManager.LoadScene("NewGameSetup");
         }
 
         private void TryAutoWire()
@@ -108,7 +101,8 @@ namespace GridironGM.UI.TeamSelection
                 teamListContent = tf;
             }
             if (!rosterPanel)
-                rosterPanel = FindFirstObjectByType<RosterPanelUI>();
+                rosterPanel = FindObjectOfType<RosterPanelUI>(true);
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- Reload roster data and ensure player rows render with clear logging
- Auto-wire player row text fields and flag missing TMP components
- Refresh team lists after bootstrapping rosters for reliable team selection

## Testing
- `dotnet build "Gridiron GM Alpha Build/Gridiron GM Alpha Build.sln"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68996f995d9883278875c854d4c76959