### PR TITLE
Persist team selection in GameState

### DIFF
--- a/Assets/Scripts/GameState.cs
+++ b/Assets/Scripts/GameState.cs
@@ -20,6 +20,8 @@ namespace GridironGM
         }
 
         public string SelectedTeamAbbr { get; set; } = "";
+        public string SelectedTeamCity { get; set; } = "";
+        public string SelectedTeamName { get; set; } = "";
 
         private void Awake()
         {


### PR DESCRIPTION
## Summary
- Save chosen team info (abbr/city/name) into `GameState`
- Revise `TeamSelectionUI` to wire roster panel, highlight rows, and persist selection without `SessionState`
- Guard confirm flow and load Dashboard scene

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a70ba6828832795374012a1eee79c