### PR TITLE
Auto-wire TeamRowUI and ensure row initialization

### DIFF
--- a/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
@@ -5,11 +5,11 @@ using GridironGM.Data;
 
 public class TeamRowUI : MonoBehaviour
 {
-    [Header("Wiring")]
-    [SerializeField] private Button button;                // Button on row root
-    [SerializeField] private Image background;             // Background Image
-    [SerializeField] private TMP_Text label;               // Optional label
-    [SerializeField] private GameObject selectedHighlight; // Optional child (border/check)
+    [Header("Wiring (optional)")]
+    [SerializeField] private Button button;                // Will auto-find if null
+    [SerializeField] private Image background;             // Will auto-find if null
+    [SerializeField] private TMP_Text label;               // Will auto-find if null
+    [SerializeField] private GameObject selectedHighlight; // Optional; we disable raycasts
 
     [Header("Colors")]
     [SerializeField] private Color normalColor = new Color(0.14f, 0.14f, 0.14f, 1f);   // #242424
@@ -18,21 +18,57 @@ public class TeamRowUI : MonoBehaviour
     public TeamData Team { get; private set; }
     public System.Action<TeamRowUI> OnClicked;
 
+    private void Awake() => AutoWireIfNeeded();
+#if UNITY_EDITOR
+    private void OnValidate() => AutoWireIfNeeded();
+#endif
+
+    private void AutoWireIfNeeded()
+    {
+        if (button == null)
+            button = GetComponent<Button>() ?? GetComponentInChildren<Button>(true);
+
+        if (background == null)
+        {
+            // Prefer an Image named "Background", else use the first Image on this GO
+            var images = GetComponentsInChildren<Image>(true);
+            foreach (var img in images)
+            {
+                if (img.gameObject == gameObject || img.name.ToLower().Contains("background"))
+                { background = img; break; }
+            }
+            if (background == null && images.Length > 0) background = images[0];
+        }
+
+        if (label == null)
+            label = GetComponentInChildren<TMP_Text>(true);
+
+        // Make sure highlight never blocks clicks
+        if (selectedHighlight != null)
+        {
+            var imgs = selectedHighlight.GetComponentsInChildren<Image>(true);
+            foreach (var img in imgs) img.raycastTarget = false;
+        }
+    }
+
     public void Init(TeamData team, System.Action<TeamRowUI> onClicked)
     {
+        AutoWireIfNeeded();
+
         Team = team;
         OnClicked = onClicked;
 
-        if (label != null)
-            label.text = $"{team.city} {team.name} ({team.abbreviation})";
-
-        if (button == null)
-            button = GetComponent<Button>();
+        if (label != null) label.text = $"{team.city} {team.name} ({team.abbreviation})";
+        else Debug.LogWarning($"[TeamRowUI] No TMP_Text found on '{name}'");
 
         if (button != null)
         {
             button.onClick.RemoveAllListeners();
             button.onClick.AddListener(() => OnClicked?.Invoke(this));
+        }
+        else
+        {
+            Debug.LogError($"[TeamRowUI] No Button found on '{name}' — row will not be clickable.");
         }
 
         SetSelected(false);
@@ -40,10 +76,8 @@ public class TeamRowUI : MonoBehaviour
 
     public void SetSelected(bool isSelected)
     {
-        if (background != null)
-            background.color = isSelected ? selectedColor : normalColor;
-
-        if (selectedHighlight != null)
-            selectedHighlight.SetActive(isSelected);
+        if (background != null) background.color = isSelected ? selectedColor : normalColor;
+        if (selectedHighlight != null) selectedHighlight.SetActive(isSelected);
     }
 }
+

--- a/Assets/Scripts/UI/TeamSelection/TeamSelectionUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamSelectionUI.cs
@@ -55,7 +55,7 @@ namespace GridironGM.UI.TeamSelection
             Debug.Log($"[TeamSelectionUI] Spawned {teams.Count} teams.");
         }
 
-        private void AddTeamRow(GridironGM.Data.TeamData t)
+        private void AddTeamRow(GridironGM.Data.TeamData team)
         {
             if (!teamListContent || !teamRowPrefab)
             {
@@ -64,14 +64,15 @@ namespace GridironGM.UI.TeamSelection
             }
 
             var rowGO = Instantiate(teamRowPrefab, teamListContent);
-            var row = rowGO.GetComponent<TeamRowUI>();
-            if (!row)
+            var rowUI = rowGO.GetComponent<TeamRowUI>();
+            if (rowUI == null)
             {
-                Debug.LogError("[TeamSelectionUI] TeamRowUI missing on teamRowPrefab.");
-                return;
+                Debug.LogError("[TeamSelection] teamRowPrefab is missing TeamRowUI.");
             }
-
-            row.Init(t, OnRowClicked);
+            else
+            {
+                rowUI.Init(team, OnRowClicked);
+            }
         }
 
         private void OnRowClicked(TeamRowUI row)


### PR DESCRIPTION
## Summary
- Auto-detect button, background, and label in TeamRowUI with runtime wiring and safe highlight handling
- Instantiate team row UI and call Init while logging missing component errors

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689a72c4562c8327814c0e60cb2fd8d9