### PR TITLE
Add team logo database and auto-wire team logos

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: deadc353198e4ef88f6b80bd3f140be9

--- a/Assets/Editor/BuildTeamLogoDatabase.cs
+++ b/Assets/Editor/BuildTeamLogoDatabase.cs
@@ -1,0 +1,47 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using GridironGM.Data;
+
+public static class BuildTeamLogoDatabase
+{
+    [MenuItem("GridironGM/Build Team Logo DB")]
+    public static void BuildDB()
+    {
+        const string inputFolder = "Assets/teamsprites";
+        const string resourcesFolder = "Assets/Resources";
+        const string assetPath = "Assets/Resources/TeamLogoDB.asset";
+
+        if (!Directory.Exists(resourcesFolder))
+            Directory.CreateDirectory(resourcesFolder);
+
+        var guids = AssetDatabase.FindAssets("t:Sprite", new[] { inputFolder });
+        var list = new List<TeamLogoEntry>();
+
+        foreach (var guid in guids)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(guid);
+            var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(path);
+            if (sprite == null) continue;
+
+            var file = Path.GetFileNameWithoutExtension(path); // e.g., ATL
+            if (string.IsNullOrEmpty(file)) continue;
+
+            list.Add(new TeamLogoEntry { abbreviation = file, sprite = sprite });
+        }
+
+        TeamLogoDatabase db = AssetDatabase.LoadAssetAtPath<TeamLogoDatabase>(assetPath);
+        if (db == null)
+        {
+            db = ScriptableObject.CreateInstance<TeamLogoDatabase>();
+            AssetDatabase.CreateAsset(db, assetPath);
+        }
+
+        db.SetEntries(list);
+        AssetDatabase.SaveAssets();
+        Debug.Log($"[LogoDB] Built with {list.Count} entries -> {assetPath}");
+    }
+}
+#endif

--- a/Assets/Editor/BuildTeamLogoDatabase.cs.meta
+++ b/Assets/Editor/BuildTeamLogoDatabase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dce916142311476ba31020d249588727

--- a/Assets/Scripts/Data/TeamLogoDatabase.cs
+++ b/Assets/Scripts/Data/TeamLogoDatabase.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GridironGM.Data
+{
+    [System.Serializable]
+    public class TeamLogoEntry
+    {
+        public string abbreviation;
+        public Sprite sprite;
+    }
+
+    public class TeamLogoDatabase : ScriptableObject
+    {
+        [SerializeField] private List<TeamLogoEntry> entries = new List<TeamLogoEntry>();
+        private Dictionary<string, Sprite> map;
+
+        private static TeamLogoDatabase _instance;
+        public static TeamLogoDatabase Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    _instance = Resources.Load<TeamLogoDatabase>("TeamLogoDB"); // Assets/Resources/TeamLogoDB.asset
+                return _instance;
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (map == null)
+            {
+                map = new Dictionary<string, Sprite>(System.StringComparer.OrdinalIgnoreCase);
+                foreach (var e in entries)
+                    if (!string.IsNullOrWhiteSpace(e.abbreviation) && e.sprite != null)
+                        map[e.abbreviation] = e.sprite;
+            }
+        }
+
+        public Sprite Get(string abbr)
+        {
+            if (string.IsNullOrEmpty(abbr)) return null;
+            if (map == null) OnEnable();
+            return map != null && map.TryGetValue(abbr, out var s) ? s : null;
+        }
+
+    #if UNITY_EDITOR
+        // Allow the editor script to set entries
+        public void SetEntries(List<TeamLogoEntry> newEntries)
+        {
+            entries = newEntries;
+            map = null;
+            UnityEditor.EditorUtility.SetDirty(this);
+        }
+    #endif
+    }
+}
+

--- a/Assets/Scripts/Data/TeamLogoDatabase.cs.meta
+++ b/Assets/Scripts/Data/TeamLogoDatabase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61f2b439fb90437d8a7ac9baab325164

--- a/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
@@ -8,6 +8,7 @@ public class TeamRowUI : MonoBehaviour
     [Header("Wiring (optional)")]
     [SerializeField] private Button button;                // Will auto-find if null
     [SerializeField] private Image background;             // Will auto-find if null
+    [SerializeField] private Image logoImage;              // Will auto-find if null
     [SerializeField] private TMP_Text label;               // Will auto-find if null
     [SerializeField] private GameObject selectedHighlight; // Optional; we disable raycasts
 
@@ -43,6 +44,21 @@ public class TeamRowUI : MonoBehaviour
         if (label == null)
             label = GetComponentInChildren<TMP_Text>(true);
 
+        if (logoImage == null)
+        {
+            // try find an Image named "Logo" first
+            foreach (var img in GetComponentsInChildren<Image>(true))
+            {
+                if (img.name.ToLower() == "logo") { logoImage = img; break; }
+            }
+            if (logoImage == null)
+            {
+                // heuristic: pick an Image child that is not the background
+                var imgs = GetComponentsInChildren<Image>(true);
+                if (imgs.Length > 1) logoImage = imgs[1];
+            }
+        }
+
         // Make sure highlight never blocks clicks
         if (selectedHighlight != null)
         {
@@ -58,8 +74,20 @@ public class TeamRowUI : MonoBehaviour
         Team = team;
         OnClicked = onClicked;
 
-        if (label != null) label.text = $"{team.city} {team.name} ({team.abbreviation})";
+        if (label != null) label.text = $"{team.city} {team.name} ({team.abbreviation})"; 
         else Debug.LogWarning($"[TeamRowUI] No TMP_Text found on '{name}'");
+
+        var sprite = TeamLogoDatabase.Instance != null ? TeamLogoDatabase.Instance.Get(team.abbreviation) : null;
+        if (logoImage != null)
+        {
+            logoImage.sprite = sprite;
+            logoImage.enabled = sprite != null;
+            logoImage.preserveAspect = true;
+        }
+        else
+        {
+            Debug.LogWarning($"[TeamRowUI] No logoImage assigned on '{name}'.");
+        }
 
         if (button != null)
         {


### PR DESCRIPTION
## Summary
- Add `TeamLogoDatabase` ScriptableObject to map team abbreviations to sprites and expose an editor setter
- Provide `BuildTeamLogoDatabase` menu item to build the database from `Assets/teamsprites`
- Extend `TeamRowUI` to auto-wire a logo Image and assign the appropriate sprite

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689a7409fa548327847150b4b0b2f698