### PR TITLE
Improve team logo loading and UI logging

### DIFF
--- a/Assets/Editor/BuildTeamLogoDatabase.cs
+++ b/Assets/Editor/BuildTeamLogoDatabase.cs
@@ -4,15 +4,13 @@ using System.IO;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
-using GridironGM.Data;
 
 public static class BuildTeamLogoDatabase
 {
     [MenuItem("GridironGM/Build Team Logo DB")]
     public static void BuildDB()
     {
-        // Support either folder name
-        var inputFolders = new[] { "Assets/TeamSprites", "Assets/teamsprites" };
+        var inputFolders = new[] { "Assets/TeamSprites", "Assets/teamsprites" }; // handle either casing
         const string resourcesPath = "Assets/Resources";
         const string assetPath     = "Assets/Resources/TeamLogoDB.asset";
 
@@ -29,6 +27,7 @@ public static class BuildTeamLogoDatabase
             return s.ToUpperInvariant();
         }
 
+        // Pull an abbreviation from filename (ATL.png, atl_logo.png, ATL-Logo@2x.png, etc.)
         var re = new Regex(@"([A-Za-z]{2,4})", RegexOptions.Compiled);
 
         foreach (var guid in spriteGuids)
@@ -60,4 +59,3 @@ public static class BuildTeamLogoDatabase
     }
 }
 #endif
-

--- a/Assets/Scripts/Data/TeamLogoDatabase.cs
+++ b/Assets/Scripts/Data/TeamLogoDatabase.cs
@@ -1,58 +1,78 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace GridironGM.Data
+[System.Serializable]
+public class TeamLogoEntry { public string abbreviation; public Sprite sprite; }
+
+public class TeamLogoDatabase : ScriptableObject
 {
-    [System.Serializable]
-    public class TeamLogoEntry
+    [SerializeField] private List<TeamLogoEntry> entries = new();
+    private Dictionary<string, Sprite> map;
+
+    public int Count => entries?.Count ?? 0;
+
+    private static TeamLogoDatabase _instance;
+    public static TeamLogoDatabase Instance
     {
-        public string abbreviation;
-        public Sprite sprite;
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = Resources.Load<TeamLogoDatabase>("TeamLogoDB"); // Assets/Resources/TeamLogoDB.asset
+                if (_instance == null) Debug.LogError("[LogoDB] TeamLogoDB.asset NOT found in Resources.");
+                else Debug.Log($"[LogoDB] Loaded DB with {_instance.Count} entries.");
+            }
+            return _instance;
+        }
     }
 
-    public class TeamLogoDatabase : ScriptableObject
+    private static string Norm(string s)
     {
-        [SerializeField] private List<TeamLogoEntry> entries = new List<TeamLogoEntry>();
-        private Dictionary<string, Sprite> map;
-
-        private static TeamLogoDatabase _instance;
-        public static TeamLogoDatabase Instance
-        {
-            get
-            {
-                if (_instance == null)
-                    _instance = Resources.Load<TeamLogoDatabase>("TeamLogoDB"); // Assets/Resources/TeamLogoDB.asset
-                return _instance;
-            }
-        }
-
-        private void OnEnable()
-        {
-            if (map == null)
-            {
-                map = new Dictionary<string, Sprite>(System.StringComparer.OrdinalIgnoreCase);
-                foreach (var e in entries)
-                    if (!string.IsNullOrWhiteSpace(e.abbreviation) && e.sprite != null)
-                        map[e.abbreviation] = e.sprite;
-            }
-        }
-
-        public Sprite Get(string abbr)
-        {
-            if (string.IsNullOrEmpty(abbr)) return null;
-            if (map == null) OnEnable();
-            return map != null && map.TryGetValue(abbr, out var s) ? s : null;
-        }
-
-    #if UNITY_EDITOR
-        // Allow the editor script to set entries
-        public void SetEntries(List<TeamLogoEntry> newEntries)
-        {
-            entries = newEntries;
-            map = null;
-            UnityEditor.EditorUtility.SetDirty(this);
-        }
-    #endif
+        if (string.IsNullOrWhiteSpace(s)) return "";
+        s = s.Trim().Replace("_", "").Replace("-", "").Replace(" ", "");
+        return s.ToUpperInvariant();
     }
+
+    private void EnsureMap()
+    {
+        if (map != null) return;
+        map = new Dictionary<string, Sprite>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in entries)
+        {
+            if (e?.sprite == null) continue;
+            var key = Norm(e.abbreviation);
+            if (string.IsNullOrEmpty(key)) continue;
+            map[key] = e.sprite;
+        }
+    }
+
+    public Sprite Get(string abbreviation)
+    {
+        EnsureMap();
+        var key = Norm(abbreviation);
+        if (string.IsNullOrEmpty(key)) return null;
+
+        if (map.TryGetValue(key, out var s)) return s;
+
+        // Optional fallback if you later drop copies into Assets/Resources/TeamLogos/ATL.png
+        var fallback = Resources.Load<Sprite>($"TeamLogos/{key}");
+        if (fallback != null)
+        {
+            Debug.LogWarning($"[LogoDB] Fallback hit for '{key}' via Resources/TeamLogos.");
+            return fallback;
+        }
+
+        Debug.LogWarning($"[LogoDB] No logo for '{key}'.");
+        return null;
+    }
+
+#if UNITY_EDITOR
+    public void SetEntries(List<TeamLogoEntry> newEntries)
+    {
+        entries = newEntries ?? new();
+        map = null;
+        UnityEditor.EditorUtility.SetDirty(this);
+    }
+#endif
 }
-

--- a/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
@@ -46,16 +47,10 @@ public class TeamRowUI : MonoBehaviour
 
         if (logoImage == null)
         {
-            // try find an Image named "Logo" first
+            // Prefer a child explicitly named "Logo"
             foreach (var img in GetComponentsInChildren<Image>(true))
             {
-                if (img.name.ToLower() == "logo") { logoImage = img; break; }
-            }
-            if (logoImage == null)
-            {
-                // heuristic: pick an Image child that is not the background
-                var imgs = GetComponentsInChildren<Image>(true);
-                if (imgs.Length > 1) logoImage = imgs[1];
+                if (img.name.Equals("Logo", System.StringComparison.OrdinalIgnoreCase)) { logoImage = img; break; }
             }
         }
 
@@ -77,16 +72,22 @@ public class TeamRowUI : MonoBehaviour
         if (label != null) label.text = $"{team.city} {team.name} ({team.abbreviation})"; 
         else Debug.LogWarning($"[TeamRowUI] No TMP_Text found on '{name}'");
 
-        var sprite = TeamLogoDatabase.Instance != null ? TeamLogoDatabase.Instance.Get(team.abbreviation) : null;
-        if (logoImage != null)
-        {
-            logoImage.sprite = sprite;
-            logoImage.enabled = sprite != null;
-            logoImage.preserveAspect = true;
-        }
+        var db = TeamLogoDatabase.Instance;
+        if (db == null) { Debug.LogError("[TeamRowUI] Logo DB not loaded."); }
         else
         {
-            Debug.LogWarning($"[TeamRowUI] No logoImage assigned on '{name}'.");
+            var sprite = db.Get(team.abbreviation);
+            if (logoImage != null)
+            {
+                logoImage.sprite = sprite;
+                logoImage.enabled = sprite != null;
+                logoImage.preserveAspect = true;
+                Debug.Log($"[TeamRowUI] Logo '{team.abbreviation}' -> {(sprite != null ? sprite.name : "null")}");
+            }
+            else
+            {
+                Debug.LogWarning($"[TeamRowUI] No logoImage assigned on '{name}'. Add an Image named 'Logo' to the prefab.");
+            }
         }
 
         if (button != null)


### PR DESCRIPTION
## Summary
- add logging and normalized lookups for team logos with fallback loading
- build tool scans TeamSprites folders for logos
- update TeamRowUI to auto-pick Logo image and report results

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a78dfc1808327a73f7d94c3f362cb