### PR TITLE
Use Resources fallback for team logos

### DIFF
--- a/Assets/Scripts/UI/TeamSelection/LogoResolver.cs
+++ b/Assets/Scripts/UI/TeamSelection/LogoResolver.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public static class LogoResolver
+{
+    private static bool _warnedDbMissing;
+
+    private static string Norm(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return "";
+        s = s.Trim().Replace("_","").Replace("-","").Replace(" ","");
+        return s.ToUpperInvariant();
+    }
+
+    public static Sprite Get(string abbreviation)
+    {
+        var key = Norm(abbreviation);
+        Sprite sprite = null;
+
+        // Try DB first (if present)
+        if (TeamLogoDatabase.Instance != null)
+        {
+            sprite = TeamLogoDatabase.Instance.Get(key);
+        }
+        else if (!_warnedDbMissing)
+        {
+            Debug.LogWarning("[Logo] TeamLogoDB.asset not found; using Resources fallback.");
+            _warnedDbMissing = true;
+        }
+
+        // Fallbacks (your sprites are here)
+        if (sprite == null)
+            sprite = Resources.Load<Sprite>($"TeamSprites/{key}");
+        if (sprite == null)
+            sprite = Resources.Load<Sprite>($"TeamLogos/{key}"); // optional extra path
+
+        return sprite;
+    }
+}

--- a/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
+++ b/Assets/Scripts/UI/TeamSelection/TeamRowUI.cs
@@ -47,10 +47,10 @@ public class TeamRowUI : MonoBehaviour
 
         if (logoImage == null)
         {
-            // Prefer a child explicitly named "Logo"
-            foreach (var img in GetComponentsInChildren<Image>(true))
+            foreach (var img in GetComponentsInChildren<UnityEngine.UI.Image>(true))
             {
-                if (img.name.Equals("Logo", System.StringComparison.OrdinalIgnoreCase)) { logoImage = img; break; }
+                if (img.name.Equals("Logo", System.StringComparison.OrdinalIgnoreCase))
+                { logoImage = img; break; }
             }
         }
 
@@ -72,22 +72,18 @@ public class TeamRowUI : MonoBehaviour
         if (label != null) label.text = $"{team.city} {team.name} ({team.abbreviation})"; 
         else Debug.LogWarning($"[TeamRowUI] No TMP_Text found on '{name}'");
 
-        var db = TeamLogoDatabase.Instance;
-        if (db == null) { Debug.LogError("[TeamRowUI] Logo DB not loaded."); }
+        // Load team logo
+        var sprite = LogoResolver.Get(team.abbreviation);
+        if (logoImage != null)
+        {
+            logoImage.sprite = sprite;
+            logoImage.enabled = sprite != null;
+            logoImage.preserveAspect = true;
+            Debug.Log($"[TeamRowUI] Logo '{team.abbreviation}' -> {(sprite ? sprite.name : "null")}");
+        }
         else
         {
-            var sprite = db.Get(team.abbreviation);
-            if (logoImage != null)
-            {
-                logoImage.sprite = sprite;
-                logoImage.enabled = sprite != null;
-                logoImage.preserveAspect = true;
-                Debug.Log($"[TeamRowUI] Logo '{team.abbreviation}' -> {(sprite != null ? sprite.name : "null")}");
-            }
-            else
-            {
-                Debug.LogWarning($"[TeamRowUI] No logoImage assigned on '{name}'. Add an Image named 'Logo' to the prefab.");
-            }
+            Debug.LogWarning($"[TeamRowUI] No logoImage assigned on '{name}'. Add an Image named 'Logo' to the prefab.");
         }
 
         if (button != null)


### PR DESCRIPTION
## Summary
- add LogoResolver to retrieve team logos from DB or Resources fallback
- update TeamRowUI to resolve logos via LogoResolver and auto-wire the logo image

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689a7aa489308327b1893e6c10a2a018