### PR TITLE
Wire dashboard tabs to data

### DIFF
--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5dec6def1f94d799276e7c791d25b15
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/GameSession.cs
+++ b/Assets/Scripts/Core/GameSession.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public static class GameSession
+{
+    const string KeyTeam = "GG.SelectedTeamAbbr";
+    const string KeyWeek = "GG.CurrentWeek";
+
+    public static string SelectedTeamAbbr
+    {
+        get => PlayerPrefs.GetString(KeyTeam, "ATL"); // default any
+        set { PlayerPrefs.SetString(KeyTeam, value); PlayerPrefs.Save(); }
+    }
+
+    public static int CurrentWeek
+    {
+        get => PlayerPrefs.GetInt(KeyWeek, 1);
+        set { PlayerPrefs.SetInt(KeyWeek, Mathf.Max(1, value)); PlayerPrefs.Save(); }
+    }
+}

--- a/Assets/Scripts/Core/GameSession.cs.meta
+++ b/Assets/Scripts/Core/GameSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e782e0f7269c435ca2bf832754b0dab8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/LeagueModels.cs
+++ b/Assets/Scripts/Data/LeagueModels.cs
@@ -1,0 +1,20 @@
+using System;
+
+[Serializable] public class Team { public string city; public string name; public string conference; public string abbreviation; }
+[Serializable] public class TeamList { public Team[] teams; }
+
+[Serializable] public class Player {
+    public string id; public string name; public string position; public int overall; public int number;
+}
+
+// rosters_by_team.json: { "ATL": [Player, ...], "BUF": [Player, ...], ... }
+[Serializable] public class RosterByTeam { public SerializableDict<string, Player[]> data; }
+
+[Serializable] public class TeamGame {
+    public int week; public string opponent; public bool home; public string time; public string result; // e.g., "W 24-17" or ""
+}
+// schedule_by_team.json: { "ATL": [TeamGame, ...], "BUF": [TeamGame, ...], ... }
+[Serializable] public class ScheduleByTeam { public SerializableDict<string, TeamGame[]> data; }
+
+// Simple serializable dict wrapper
+[Serializable] public class SerializableDict<TKey, TValue> { public System.Collections.Generic.List<TKey> keys; public System.Collections.Generic.List<TValue> values; }

--- a/Assets/Scripts/Data/LeagueModels.cs.meta
+++ b/Assets/Scripts/Data/LeagueModels.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20b56594fd2d4bc1907a89ffb1d97508
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/LeagueRepository.cs
+++ b/Assets/Scripts/Data/LeagueRepository.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+
+public static class LeagueRepository
+{
+    // Tries persistent path first (runtime saves), falls back to Resources/Config
+    private static string PersistPath => Application.persistentDataPath;
+
+    public static Team[] GetTeams()
+    {
+        if (TryLoadText("teams.json", out var json)) return JsonUtility.FromJson<TeamList>(json)?.teams ?? Array.Empty<Team>();
+        if (TryLoadResource("Config/teams", out var resJson)) return JsonUtility.FromJson<TeamList>(resJson)?.teams ?? Array.Empty<Team>();
+        Debug.LogWarning("[LeagueRepository] teams.json not found.");
+        return Array.Empty<Team>();
+    }
+
+    public static List<Player> GetRoster(string abbr)
+    {
+        if (string.IsNullOrEmpty(abbr)) return new List<Player>();
+        if (TryLoadText("rosters_by_team.json", out var json)) return ParseRoster(json, abbr);
+        if (TryLoadResource("Generated/rosters_by_team", out var resJson)) return ParseRoster(resJson, abbr);
+        Debug.LogWarning("[LeagueRepository] rosters_by_team.json not found. Returning placeholder roster.");
+        return PlaceholderRoster();
+    }
+
+    public static List<TeamGame> GetTeamSchedule(string abbr)
+    {
+        if (string.IsNullOrEmpty(abbr)) return new List<TeamGame>();
+        if (TryLoadText("schedule_by_team.json", out var json)) return ParseSchedule(json, abbr);
+        if (TryLoadResource("Generated/schedule_by_team", out var resJson)) return ParseSchedule(resJson, abbr);
+        Debug.LogWarning("[LeagueRepository] schedule_by_team.json not found.");
+        return new List<TeamGame>();
+    }
+
+    // ===== helpers =====
+    private static bool TryLoadText(string fileName, out string json)
+    {
+        json = null;
+        var path = Path.Combine(PersistPath, fileName);
+        if (!File.Exists(path)) return false;
+        json = File.ReadAllText(path);
+        return !string.IsNullOrEmpty(json);
+    }
+    private static bool TryLoadResource(string resPath, out string json)
+    {
+        json = null;
+        var ta = Resources.Load<TextAsset>(resPath);
+        if (ta == null) return false;
+        json = ta.text;
+        return !string.IsNullOrEmpty(json);
+    }
+
+    private static List<Player> ParseRoster(string json, string abbr)
+    {
+        try
+        {
+            // manual parse for { "ATL":[...], "BUF":[...] }
+            var root = JsonUtility.FromJson<Wrapper>(Wrap(json));
+            return root.GetList<Player>(abbr) ?? PlaceholderRoster();
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"[LeagueRepository] Roster parse failed: {e.Message}");
+            return PlaceholderRoster();
+        }
+    }
+    private static List<TeamGame> ParseSchedule(string json, string abbr)
+    {
+        try
+        {
+            var root = JsonUtility.FromJson<Wrapper>(Wrap(json));
+            return root.GetList<TeamGame>(abbr) ?? new List<TeamGame>();
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning($"[LeagueRepository] Schedule parse failed: {e.Message}");
+            return new List<TeamGame>();
+        }
+    }
+
+    // JsonUtility can’t do dicts; wrap into a field name
+    [Serializable] private class Wrapper { public string _raw;
+        public List<T> GetList<T>(string key)
+        {
+            // crude extraction: "key":[ ... ] ; assumes well-formed JSON
+            var target = $"\"{key}\"";
+            int i = _raw.IndexOf(target, StringComparison.OrdinalIgnoreCase);
+            if (i < 0) return null;
+            int s = _raw.IndexOf('[', i);
+            int e = _raw.IndexOf(']', s);
+            if (s < 0 || e < 0) return null;
+            string arr = _raw.Substring(s, e - s + 1);
+            return JsonArray<T>(arr);
+        }
+    }
+    private static string Wrap(string raw) => "{\"_raw\":" + JsonUtility.ToJson(raw) + "}";
+    private static List<T> JsonArray<T>(string arr) => new List<T>(JsonHelper.FromJson<T>(arr));
+
+    private static List<Player> PlaceholderRoster()
+    {
+        var list = new List<Player>();
+        for (int i = 0; i < 12; i++) list.Add(new Player { id = Guid.NewGuid().ToString("N"), name = $"Player {i+1}", position = "WR", overall = UnityEngine.Random.Range(60, 85), number = 10 + i });
+        return list;
+    }
+}
+
+// JsonUtility array helper
+public static class JsonHelper
+{
+    public static T[] FromJson<T>(string json)
+    {
+        string wrapped = "{\"items\":" + json + "}";
+        Wrapper<T> w = JsonUtility.FromJson<Wrapper<T>>(wrapped);
+        return w.items ?? Array.Empty<T>();
+    }
+    [Serializable] private class Wrapper<T> { public T[] items; }
+}

--- a/Assets/Scripts/Data/LeagueRepository.cs.meta
+++ b/Assets/Scripts/Data/LeagueRepository.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56afb5f7c9c74cf4b466ea8e5f4ffde4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/DepthChartsBinder.cs
+++ b/Assets/Scripts/UI/DepthChartsBinder.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+
+public class DepthChartsBinder : MonoBehaviour
+{
+    [SerializeField] private Transform contentParent;
+    [SerializeField] private GameObject textRowPrefab; // a simple TMP_Text row
+    [SerializeField] private TMP_Text headerText;
+    [SerializeField] private int slotsPerPosition = 2; // show top N per position
+
+    private static readonly string[] Order = { "QB","RB","WR","TE","LT","LG","C","RG","RT","EDGE","DE","DT","LB","CB","S","K","P" };
+
+    public void Refresh()
+    {
+        if (contentParent == null || textRowPrefab == null) { Debug.LogWarning("[DepthChartsBinder] Missing refs"); return; }
+        for (int i = contentParent.childCount - 1; i >= 0; i--) Destroy(contentParent.GetChild(i).gameObject);
+
+        string abbr = GameSession.SelectedTeamAbbr;
+        headerText?.SetText($"{abbr} • Depth Chart");
+        var roster = LeagueRepository.GetRoster(abbr);
+        if (roster.Count == 0) return;
+
+        var byPos = roster.GroupBy(p => p.position)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(p => p.overall).ToList());
+
+        foreach (var pos in Order)
+        {
+            if (!byPos.TryGetValue(pos, out var list) || list.Count == 0) continue;
+            // Pos header
+            var h = Instantiate(textRowPrefab, contentParent).GetComponentInChildren<TMP_Text>();
+            h.fontStyle = FontStyles.Bold;
+            h.SetText(pos);
+            // Slots
+            for (int i = 0; i < Mathf.Min(slotsPerPosition, list.Count); i++)
+            {
+                var row = Instantiate(textRowPrefab, contentParent).GetComponentInChildren<TMP_Text>();
+                var p = list[i];
+                row.SetText($"{i+1}. {p.name}  ({p.overall})");
+            }
+        }
+        Canvas.ForceUpdateCanvases();
+    }
+}

--- a/Assets/Scripts/UI/DepthChartsBinder.cs.meta
+++ b/Assets/Scripts/UI/DepthChartsBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f9b45f10103486dbca1fd63e3242355
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/DepthChartsPanelView.cs
+++ b/Assets/Scripts/UI/DepthChartsPanelView.cs
@@ -4,8 +4,6 @@ public class DepthChartsPanelView : MonoBehaviour, ITabView
 {
     public void OnTabShown()
     {
-        // If you have a binder, call it here:
-        // GetComponent<DepthChartsBinder>()?.Refresh();
-        Debug.Log("[DepthChartsPanelView] Refresh on show");
+        GetComponent<DepthChartsBinder>()?.Refresh();
     }
 }

--- a/Assets/Scripts/UI/RosterBinder.cs
+++ b/Assets/Scripts/UI/RosterBinder.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class RosterBinder : MonoBehaviour
+{
+    [Header("Prefabs & Targets")]
+    [SerializeField] private Transform contentParent;
+    [SerializeField] private GameObject playerRowPrefab;
+    [SerializeField] private TMP_Text headerText;
+
+    public void Refresh()
+    {
+        if (contentParent == null || playerRowPrefab == null) { Debug.LogWarning("[RosterBinder] Missing refs"); return; }
+        Clear();
+        string abbr = GameSession.SelectedTeamAbbr;
+        var roster = LeagueRepository.GetRoster(abbr);
+        headerText?.SetText($"{abbr} • {roster.Count} players");
+
+        foreach (var p in roster.OrderByDescending(p => p.overall).ThenBy(p => p.position))
+        {
+            var row = Instantiate(playerRowPrefab, contentParent);
+            var ui = row.GetComponent<PlayerRowUI>();
+            if (ui != null)
+            {
+                ui.nameText.SetText(p.name);
+                ui.posText.SetText(p.position);
+                ui.ovrText.SetText(p.overall.ToString());
+            }
+            else
+            {
+                // fallback: find by child names
+                TrySet(row, "NameText", p.name);
+                TrySet(row, "PosText", p.position);
+                TrySet(row, "OvrText", p.overall.ToString());
+            }
+        }
+        LayoutRebuild();
+    }
+
+    private void TrySet(GameObject row, string childName, string text)
+    {
+        var t = row.transform.Find(childName)?.GetComponent<TMP_Text>();
+        if (t) t.SetText(text);
+    }
+
+    private void Clear()
+    {
+        for (int i = contentParent.childCount - 1; i >= 0; i--)
+            Destroy(contentParent.GetChild(i).gameObject);
+    }
+    private void LayoutRebuild()
+    {
+        Canvas.ForceUpdateCanvases();
+        var rt = contentParent as RectTransform;
+        if (rt) UnityEngine.UI.LayoutRebuilder.ForceRebuildLayoutImmediate(rt);
+        Canvas.ForceUpdateCanvases();
+    }
+}

--- a/Assets/Scripts/UI/RosterBinder.cs.meta
+++ b/Assets/Scripts/UI/RosterBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7a99c13a12041f8a003f7a3b2e35ac1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/RosterPanelView.cs
+++ b/Assets/Scripts/UI/RosterPanelView.cs
@@ -2,11 +2,8 @@ using UnityEngine;
 
 public class RosterPanelView : MonoBehaviour, ITabView
 {
-    // Inject or find your binder script here if you have one
     public void OnTabShown()
     {
-        // Call your existing refresh logic, e.g.:
-        // GetComponent<RosterBinder>()?.Refresh();
-        Debug.Log("[RosterPanelView] Refresh on show");
+        GetComponent<RosterBinder>()?.Refresh();
     }
 }

--- a/Assets/Scripts/UI/Rows.meta
+++ b/Assets/Scripts/UI/Rows.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07e869c6f95c4fc99c8dc036278b591c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Rows/PlayerRowUI.cs
+++ b/Assets/Scripts/UI/Rows/PlayerRowUI.cs
@@ -1,0 +1,9 @@
+using TMPro;
+using UnityEngine;
+
+public class PlayerRowUI : MonoBehaviour
+{
+    public TMP_Text nameText;
+    public TMP_Text posText;
+    public TMP_Text ovrText;
+}

--- a/Assets/Scripts/UI/Rows/PlayerRowUI.cs.meta
+++ b/Assets/Scripts/UI/Rows/PlayerRowUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2f0e7c392a84e7689e169f863b91342
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/ScheduleBinder.cs
+++ b/Assets/Scripts/UI/ScheduleBinder.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using TMPro;
+using UnityEngine;
+
+public class ScheduleBinder : MonoBehaviour
+{
+    [SerializeField] private Transform contentParent;
+    [SerializeField] private GameObject textRowPrefab; // simple row with a TMP_Text
+    [SerializeField] private TMP_Text headerText;
+
+    public void Refresh()
+    {
+        if (contentParent == null || textRowPrefab == null) { Debug.LogWarning("[ScheduleBinder] Missing refs"); return; }
+        for (int i = contentParent.childCount - 1; i >= 0; i--) Destroy(contentParent.GetChild(i).gameObject);
+
+        string abbr = GameSession.SelectedTeamAbbr;
+        var games = LeagueRepository.GetTeamSchedule(abbr);
+        headerText?.SetText($"{abbr} • Schedule");
+        int curWeek = GameSession.CurrentWeek;
+
+        foreach (var g in games.OrderBy(g => g.week))
+        {
+            var row = Instantiate(textRowPrefab, contentParent);
+            var txt = row.GetComponentInChildren<TMP_Text>();
+            string vs = g.home ? "vs" : "@";
+            string res = string.IsNullOrEmpty(g.result) ? "" : $"  •  {g.result}";
+            txt.SetText($"Week {g.week}: {vs} {g.opponent}{res}");
+
+            // highlight current week
+            if (g.week == curWeek)
+            {
+                var cg = row.GetComponent<CanvasGroup>() ?? row.AddComponent<CanvasGroup>();
+                cg.alpha = 1f;
+                row.transform.localScale = Vector3.one * 1.02f;
+            }
+        }
+
+        Canvas.ForceUpdateCanvases();
+    }
+}

--- a/Assets/Scripts/UI/ScheduleBinder.cs.meta
+++ b/Assets/Scripts/UI/ScheduleBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 670f7d0f05684c9089ba35885de7e092
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/SchedulePanelView.cs
+++ b/Assets/Scripts/UI/SchedulePanelView.cs
@@ -4,7 +4,6 @@ public class SchedulePanelView : MonoBehaviour, ITabView
 {
     public void OnTabShown()
     {
-        // GetComponent<ScheduleBinder>()?.Refresh();
-        Debug.Log("[SchedulePanelView] Refresh on show");
+        GetComponent<ScheduleBinder>()?.Refresh();
     }
 }


### PR DESCRIPTION
## Summary
- Implemented GameSession for storing selected team and week
- Added league data models and repository that load JSON with fallbacks and placeholders
- Created binder scripts for roster, schedule, and depth chart tabs and wired panel views to refresh on show

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ad116d2f48327b9aa82ef2f1010be