### PR TITLE
feat: add dashboard tab system

### DIFF
--- a/Assets/Scripts/UI/ScreenManager.cs
+++ b/Assets/Scripts/UI/ScreenManager.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GridironGM.UI
+{
+    /// <summary>
+    /// Controls visibility of page panels. Exactly one page is active at a time.
+    /// </summary>
+    public class ScreenManager : MonoBehaviour
+    {
+        [Tooltip("Pages managed by this screen manager.")]
+        public List<GameObject> pages = new List<GameObject>();
+
+        [Tooltip("Page displayed on start.")]
+        public GameObject defaultPage;
+
+        private void Awake()
+        {
+            // Auto-discover pages if list is empty
+            if (pages == null || pages.Count == 0)
+            {
+                Transform pagesRoot = transform.Find("Pages");
+                if (pagesRoot != null)
+                {
+                    pages = new List<GameObject>();
+                    foreach (Transform child in pagesRoot)
+                        pages.Add(child.gameObject);
+                }
+                else
+                {
+                    Debug.LogWarning("[ScreenManager] 'Pages' container not found.", this);
+                }
+            }
+
+            if (pages == null)
+                pages = new List<GameObject>();
+
+            foreach (var p in pages)
+                if (p) p.SetActive(false);
+
+            if (defaultPage == null && pages.Count > 0)
+                defaultPage = pages[0];
+
+            if (defaultPage != null && !pages.Contains(defaultPage))
+                pages.Add(defaultPage);
+
+            if (defaultPage != null)
+            {
+                defaultPage.SetActive(true);
+                Debug.Log($"[ScreenManager] Default page active: {defaultPage.name}");
+            }
+            else
+            {
+                Debug.LogWarning("[ScreenManager] No default page set.", this);
+            }
+
+            Debug.Log($"[ScreenManager] Registered {pages.Count} pages.");
+        }
+
+        /// <summary>
+        /// Show the requested page. Falls back to default page on invalid input.
+        /// </summary>
+        public void Show(GameObject page)
+        {
+            if (page == null)
+            {
+                Debug.LogError("[ScreenManager] Show called with null page.", this);
+                page = defaultPage;
+            }
+
+            if (!pages.Contains(page))
+            {
+                Debug.LogWarning($"[ScreenManager] Page '{page?.name}' not registered. Using default page.", this);
+                page = defaultPage;
+            }
+
+            foreach (var p in pages)
+            {
+                if (p == null) continue;
+                bool active = p == page;
+                if (p.activeSelf != active)
+                    p.SetActive(active);
+            }
+
+            if (page != null)
+                Debug.Log($"[ScreenManager] Showing page: {page.name}");
+        }
+    }
+}
+

--- a/Assets/Scripts/UI/TabButton.cs
+++ b/Assets/Scripts/UI/TabButton.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace GridironGM.UI
+{
+    [RequireComponent(typeof(Button))]
+    public class TabButton : MonoBehaviour
+    {
+        [SerializeField] private GameObject targetPage;
+        private ScreenManager manager;
+
+        private void Awake()
+        {
+            manager = GetComponentInParent<ScreenManager>();
+            if (manager == null)
+                Debug.LogError("[TabButton] ScreenManager not found in parent hierarchy.", this);
+
+            var button = GetComponent<Button>();
+            button.onClick.AddListener(OnClick);
+
+            if (GetComponent<Toggle>() != null)
+                Debug.LogWarning("[TabButton] Tab should not have a Toggle component.", this);
+        }
+
+        public void OnClick()
+        {
+            if (targetPage == null)
+            {
+                Debug.LogError("[TabButton] Target page not assigned.", this);
+                return;
+            }
+
+            if (manager == null)
+            {
+                Debug.LogError("[TabButton] ScreenManager reference missing.", this);
+                return;
+            }
+
+            manager.Show(targetPage);
+        }
+
+        private void OnValidate()
+        {
+            if (targetPage == null)
+                Debug.LogWarning("[TabButton] targetPage is not set.", this);
+        }
+    }
+}
+

--- a/Assets/Scripts/UI/TabButtonBinder.cs
+++ b/Assets/Scripts/UI/TabButtonBinder.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace GridironGM.UI
+{
+    /// <summary>
+    /// Optional helper placed on a Tabs root to auto-wire child TabButtons.
+    /// </summary>
+    public class TabButtonBinder : MonoBehaviour
+    {
+        private void Awake()
+        {
+            var tabs = GetComponentsInChildren<TabButton>(true);
+            foreach (var tab in tabs)
+            {
+                var btn = tab.GetComponent<Button>();
+                if (btn == null) continue;
+                btn.onClick.RemoveListener(tab.OnClick);
+                btn.onClick.AddListener(tab.OnClick);
+            }
+            Debug.Log($"[TabButtonBinder] Wired {tabs.Length} tabs under {name}.");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement ScreenManager to control dashboard page visibility
- add TabButton component to trigger page switches and validations
- add optional TabButtonBinder for auto-wiring tab buttons

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689d1c93109083279aae9055331b6005