### PR TITLE
Handle array root in team data loader

### DIFF
--- a/Assets/Scripts/Data/LeagueRepository.cs
+++ b/Assets/Scripts/Data/LeagueRepository.cs
@@ -9,7 +9,12 @@ public static class LeagueRepository
     {
         var json = LoadJson("teams.json", new[] { "Config/teams", "teams" }, out var src);
         if (string.IsNullOrEmpty(json)) return Array.Empty<Team>();
-        var teams = JsonUtility.FromJson<TeamList>(json)?.teams ?? Array.Empty<Team>();
+
+        json = json.Trim();
+        Team[] teams = json.StartsWith("[")
+            ? JsonHelper.FromJson<Team>(json)
+            : JsonUtility.FromJson<TeamList>(json)?.teams ?? Array.Empty<Team>();
+
         Debug.Log($"[LeagueRepository] Teams count: {teams.Length}");
         return teams;
     }


### PR DESCRIPTION
## Summary
- support parsing `teams.json` when it is an array by detecting and wrapping array roots automatically

## Testing
- `dotnet test` *(fails: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e0687208327b6c8ce021a3a97e3