### PR TITLE
Add missing script cleaner and safer team selection UI

### DIFF
--- a/Assets/Editor/RemoveMissingScripts.cs
+++ b/Assets/Editor/RemoveMissingScripts.cs
@@ -1,0 +1,16 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+
+public static class RemoveMissingScripts
+{
+    [MenuItem("GridironGM/Remove Missing Scripts In Scene")]
+    public static void Remove()
+    {
+        int total = 0;
+        foreach (var go in Object.FindObjectsOfType<GameObject>())
+            total += GameObjectUtility.RemoveMonoBehavioursWithMissingScript(go);
+        Debug.Log($"[Tools] Removed {total} missing script component(s) from scene.");
+    }
+}
+#endif

--- a/Assets/Editor/RemoveMissingScripts.cs.meta
+++ b/Assets/Editor/RemoveMissingScripts.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cea6e3663ec64be6a6edc25381d23cea

--- a/Assets/Scripts/UI/TeamSelectionUI.cs
+++ b/Assets/Scripts/UI/TeamSelectionUI.cs
@@ -1,54 +1,74 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using GG.Game;
 
 [Serializable]
-public class TeamData
-{
-    public string city;
-    public string name;
-    public string conference;
-    public string abbreviation;
-}
-
+public class TeamData { public string city; public string name; public string conference; public string abbreviation; }
 [Serializable]
-public class TeamDataList
-{
-    public List<TeamData> teams = new();
-}
+public class TeamDataList { public List<TeamData> teams = new(); }
 
 public class TeamSelectionUI : MonoBehaviour
 {
     [Header("Left List")]
-    [SerializeField] private Transform listContent;      // Scroll/Viewport/Content for team rows
-    [SerializeField] private GameObject teamRowPrefab;   // TeamRowUI prefab with TMP texts
+    [SerializeField] private Transform listContent;    // Scroll/Viewport/Content
+    [SerializeField] private GameObject teamRowPrefab; // TeamRowUI prefab
 
     [Header("Buttons")]
-    [SerializeField] private Button confirmButton;
+    [SerializeField] private Button confirmButton;     // ConfirmTeamButton
 
-    private List<TeamData> _teams;
+    private List<TeamData> _teams = new();
+
+    void Awake()
+    {
+        // Auto-wire to survive lost references
+        if (!confirmButton)
+        {
+            var go = GameObject.Find("ConfirmTeamButton");
+            if (go) confirmButton = go.GetComponent<Button>();
+        }
+        if (!listContent)
+        {
+            var go = GameObject.Find("LeftPanel/Viewport/Content");
+            if (go) listContent = go.transform;
+        }
+        // teamRowPrefab stays serialized; if null we will error clearly in Start
+    }
 
     void Start()
     {
+        if (!confirmButton) { Debug.LogError("[TeamSelectionUI] ConfirmButton is not assigned."); return; }
+        if (!listContent)   { Debug.LogError("[TeamSelectionUI] List Content is not assigned.");   return; }
+        if (!teamRowPrefab) { Debug.LogError("[TeamSelectionUI] Team Row Prefab is not assigned."); return; }
+
         confirmButton.interactable = false;
-        LoadTeams();
+        if (!TryLoadTeams(out _teams)) return;
         PopulateTeamList();
     }
 
-    void LoadTeams()
+    bool TryLoadTeams(out List<TeamData> teams)
     {
-        string path = Path.Combine(Application.streamingAssetsPath, "teams.json");
-        string json = File.ReadAllText(path);
-        if (json.TrimStart().StartsWith("[")) json = "{\"teams\":" + json + "}"; // allow array root
-        var data = JsonUtility.FromJson<TeamDataList>(json);
-        _teams = data?.teams ?? new List<TeamData>();
-        _teams.Sort((a,b) => string.Compare(a.name, b.name, StringComparison.Ordinal));
-        Debug.Log($"[TeamSelectionUI] Teams count: {_teams.Count}");
+        teams = new List<TeamData>();
+        try
+        {
+            string path = Path.Combine(Application.streamingAssetsPath, "teams.json");
+            if (!File.Exists(path)) { Debug.LogError($"[TeamSelectionUI] Missing teams.json at {path}"); return false; }
+            string json = File.ReadAllText(path);
+            if (json.TrimStart().StartsWith("[")) json = "{\"teams\":" + json + "}"; // allow array root
+            var data = JsonUtility.FromJson<TeamDataList>(json);
+            teams = data?.teams ?? new List<TeamData>();
+            teams.Sort((a,b) => string.Compare(a.name, b.name, StringComparison.Ordinal));
+            Debug.Log($"[TeamSelectionUI] Teams count: {teams.Count}");
+            return true;
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[TeamSelectionUI] Failed to load teams.json: {e}");
+            return false;
+        }
     }
 
     void PopulateTeamList()


### PR DESCRIPTION
## Summary
- Auto-wire TeamSelectionUI references and guard against missing configuration
- Add Unity editor tool to remove missing script components from the active scene

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689d24a8946c83278b21698a8eac98c6