### PR TITLE
Add roster UI services and logo utilities

### DIFF
--- a/Assets/Scripts/Data/RosterService.cs
+++ b/Assets/Scripts/Data/RosterService.cs
@@ -15,9 +15,9 @@ public static class RosterService
     public static TeamRosterDTO LoadRosterFor(string abbr)
     {
         EnsureLoaded();
-        if (_cache.TryGetValue(abbr.ToUpperInvariant(), out var t)) return t;
-        Debug.LogError($"[RosterService] Roster not found for {abbr}");
-        return null;
+        if (string.IsNullOrEmpty(abbr)) return null;
+        _cache.TryGetValue(abbr.ToUpperInvariant(), out var t);
+        return t;
     }
 
     private static void EnsureLoaded()
@@ -25,6 +25,7 @@ public static class RosterService
         if (_loaded) return;
         string path = Path.Combine(Application.streamingAssetsPath, "rosters_by_team.json");
         if (!File.Exists(path)) { Debug.LogError($"[RosterService] Missing {path}"); _cache = new(); _loaded = true; return; }
+
         string json = File.ReadAllText(path).TrimStart();
         if (json.StartsWith("[")) json = "{\"teams\":" + json + "}";
 

--- a/Assets/Scripts/Services/LogoService.cs
+++ b/Assets/Scripts/Services/LogoService.cs
@@ -23,5 +23,6 @@ public static class LogoService
         foreach (var e in db.items)
             if (!string.IsNullOrEmpty(e.abbr) && e.sprite)
                 _map[e.abbr.ToUpperInvariant()] = e.sprite;
+        Debug.Log($"[LogoService] Loaded logos: {_map.Count}");
     }
 }

--- a/Assets/Scripts/Services/TeamLogoDatabase.cs
+++ b/Assets/Scripts/Services/TeamLogoDatabase.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu(menuName = "GridironGM/Team Logo Database")]
+[CreateAssetMenu(menuName = "GridironGM/Team Logo Database", fileName = "TeamLogoDatabase")]
 public class TeamLogoDatabase : ScriptableObject
 {
     [Serializable] public struct Entry { public string abbr; public Sprite sprite; }

--- a/Assets/Scripts/UI/Compat/PlayerRowUI.cs
+++ b/Assets/Scripts/UI/Compat/PlayerRowUI.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
 // Legacy shim so old prefabs that referenced PlayerRowUI keep working.
-// Require new binder so rows still populate.
+// Requires the new binder so rows still populate.
 [RequireComponent(typeof(PlayerRowBinder))]
 public class PlayerRowUI : MonoBehaviour { }

--- a/Assets/Scripts/UI/Compat/RosterBinder.cs
+++ b/Assets/Scripts/UI/Compat/RosterBinder.cs
@@ -1,3 +1,3 @@
-// Legacy shim: old code referenced RosterBinder.
-// Inherit from the new PlayerRowBinder so behavior is identical.
+// Legacy shim: previous code referenced RosterBinder.
+// Keep behavior identical by inheriting from the new binder.
 public class RosterBinder : PlayerRowBinder { }

--- a/Assets/Scripts/UI/RosterPanelUI.cs
+++ b/Assets/Scripts/UI/RosterPanelUI.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+public class RosterPanelUI : MonoBehaviour
+{
+    [SerializeField] Transform content;        // Scroll View / Viewport / Content
+    [SerializeField] GameObject playerRowPrefab; // PlayerRowUI prefab
+
+    public void ShowRosterForTeam(string abbr)
+    {
+        if (!EnsureWired()) { Debug.LogWarning("[RosterPanel] Missing refs"); return; }
+        var team = RosterService.LoadRosterFor(abbr);
+        if (team?.players == null) { Debug.LogWarning($"[RosterPanel] No roster for {abbr}"); return; }
+
+        for (int i = content.childCount - 1; i >= 0; i--)
+            Destroy(content.GetChild(i).gameObject);
+
+        int count = 0;
+        foreach (var p in team.players)
+        {
+            var row = Instantiate(playerRowPrefab, content);
+            var binder = row.GetComponent<PlayerRowBinder>() ?? row.AddComponent<PlayerRowBinder>();
+            binder.Bind(p);
+            count++;
+        }
+        Debug.Log($"[RosterPanel] Rendered {count} players for {abbr}");
+    }
+
+    bool EnsureWired()
+    {
+        if (!content)
+        {
+            var sr = GetComponentInChildren<UnityEngine.UI.ScrollRect>(true);
+            if (sr && sr.content) content = sr.content;
+        }
+        if (!playerRowPrefab)
+        {
+            var res = Resources.Load<GameObject>("UI/PlayerRowUI");
+            if (res) playerRowPrefab = res;
+        }
+        return content && playerRowPrefab;
+    }
+}

--- a/Assets/Scripts/UI/RosterPanelUI.cs.meta
+++ b/Assets/Scripts/UI/RosterPanelUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4106f1f47456450dbee857a9bb9d0faf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/TeamRowUI.cs
+++ b/Assets/Scripts/UI/TeamRowUI.cs
@@ -1,0 +1,49 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class TeamRowUI : MonoBehaviour
+{
+    [Header("Refs")]
+    public Image logoImage;
+    public TMP_Text nameText;
+    public TMP_Text conferenceText;
+    public Button button;
+
+    public void Set(TeamData data, System.Action onClick)
+    {
+        AutoWireIfNeeded();
+
+        if (nameText)      nameText.text = $"{data.city} {data.name} ({data.abbreviation})";
+        if (conferenceText) conferenceText.text = data.conference;
+
+        if (button)
+        {
+            button.onClick.RemoveAllListeners();
+            if (onClick != null) button.onClick.AddListener(() => onClick());
+        }
+
+        if (logoImage)
+        {
+            var spr = LogoService.Get(data.abbreviation);
+            logoImage.enabled = spr != null;
+            logoImage.sprite = spr;
+            logoImage.preserveAspect = true;
+        }
+    }
+
+    void AutoWireIfNeeded()
+    {
+        if (!button) button = GetComponent<Button>();
+        if (!logoImage) logoImage = GetComponentInChildren<Image>(true);
+        if (!nameText || !conferenceText)
+        {
+            var tmps = GetComponentsInChildren<TMP_Text>(true);
+            if (tmps.Length >= 2)
+            {
+                if (!nameText) nameText = tmps[0];
+                if (!conferenceText) conferenceText = tmps[1];
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/TeamRowUI.cs.meta
+++ b/Assets/Scripts/UI/TeamRowUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69ccabfbda314740b9992b3ec72eca1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add ProjectCleanup editor tool to remove legacy scripts and missing components
- Provide shims and binders for player rows and rosters
- Add team logo database, logo service, and builder
- Implement TeamRowUI and RosterPanelUI to display logos and rosters
- Enhance roster service to load and cache team rosters

## Testing
- `dotnet build` *(fails: The current working directory does not contain a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689d330cb0088327aaa89bc607b6177d