### PR TITLE
Respect selected team on Dashboard

### DIFF
--- a/Assets/Scripts/Game/GameState.cs
+++ b/Assets/Scripts/Game/GameState.cs
@@ -1,9 +1,8 @@
-using UnityEngine;
-
 namespace GG.Game
 {
     public static class GameState
     {
+        // Set in TeamSelection, read in Dashboard
         public static string SelectedTeamAbbr = "";
     }
 }

--- a/Assets/Scripts/UI/DashboardBootstrap.cs
+++ b/Assets/Scripts/UI/DashboardBootstrap.cs
@@ -1,19 +1,28 @@
-using GG.Game;
 using UnityEngine;
 
-public class DashboardBootstrap : MonoBehaviour
+namespace GG.Game
 {
-    void Start()
+    // Run after most scripts so we override any default team selection
+    [DefaultExecutionOrder(1000)]
+    public class DashboardBootstrap : MonoBehaviour
     {
-        var panel = FindFirstObjectByType<RosterPanelUI>(FindObjectsInactive.Include);
-        if (!panel)
+        void Start()
         {
-            Debug.LogWarning("[DashboardBootstrap] No RosterPanelUI found in Dashboard.");
-            return;
-        }
+            var panel = FindFirstObjectByType<RosterPanelUI>(FindObjectsInactive.Include);
+            if (!panel)
+            {
+                Debug.LogWarning("[DashboardBootstrap] No RosterPanelUI found in Dashboard.");
+                return;
+            }
 
-        var abbr = string.IsNullOrEmpty(GameState.SelectedTeamAbbr) ? "ATL" : GameState.SelectedTeamAbbr;
-        Debug.Log($"[DashboardBootstrap] Showing roster for {abbr}");
-        panel.ShowRosterForTeam(abbr);
+            // Prefer in-memory selection; fall back to PlayerPrefs; default to ATL
+            var abbr = !string.IsNullOrEmpty(GameState.SelectedTeamAbbr)
+                       ? GameState.SelectedTeamAbbr
+                       : PlayerPrefs.GetString("selected_team", "ATL");
+
+            Debug.Log($"[DashboardBootstrap] Showing roster for {abbr}");
+            panel.ShowRosterForTeam(abbr);
+        }
     }
 }
+

--- a/Assets/Scripts/UI/TeamSelectionUI.cs
+++ b/Assets/Scripts/UI/TeamSelectionUI.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using GG.Game;
 
@@ -79,9 +78,16 @@ public class TeamSelectionUI : MonoBehaviour
             Debug.LogWarning("[TeamSelectionUI] Confirm clicked with no team selected.");
             return;
         }
+
+        // Primary: in-memory (survives scene load)
         GameState.SelectedTeamAbbr = selectedAbbr;
+
+        // Fallback: persists across domain reloads/editor recompiles
+        PlayerPrefs.SetString("selected_team", selectedAbbr);
+        PlayerPrefs.Save();
+
         Debug.Log($"[TeamSelectionUI] Confirm → Dashboard for {selectedAbbr}");
-        SceneManager.LoadScene("Dashboard", LoadSceneMode.Single);
+        UnityEngine.SceneManagement.SceneManager.LoadScene("Dashboard", UnityEngine.SceneManagement.LoadSceneMode.Single);
     }
 
     List<TeamData> LoadTeamsFromStreamingAssets()


### PR DESCRIPTION
## Summary
- add GameState static to track selected team abbreviation across scenes
- persist team selection on confirm and load Dashboard
- bootstrap Dashboard with selected team, defaulting to previous or ATL

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689d4bec2a6c832795e219e01dd7624a