### PR TITLE
feat: show selected team on dashboard

### DIFF
--- a/Assets/Scripts/UI/DashboardBootstrap.cs
+++ b/Assets/Scripts/UI/DashboardBootstrap.cs
@@ -1,27 +1,38 @@
+using GG.Game;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace GG.Game
 {
-    // Run after most scripts so we override any default team selection
+    // Runs as a component (if present) and ALSO as a global hook after scene load
     [DefaultExecutionOrder(1000)]
     public class DashboardBootstrap : MonoBehaviour
     {
-        void Start()
-        {
-            var panel = FindFirstObjectByType<RosterPanelUI>(FindObjectsInactive.Include);
-            if (!panel)
-            {
-                Debug.LogWarning("[DashboardBootstrap] No RosterPanelUI found in Dashboard.");
-                return;
-            }
+        void Start() { ApplySelectionToDashboard(); }
 
-            // Prefer in-memory selection; fall back to PlayerPrefs; default to ATL
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        static void AfterSceneLoadHook()
+        {
+            var active = SceneManager.GetActiveScene();
+            if (active.name == "Dashboard")
+                ApplySelectionToDashboard();
+        }
+
+        static void ApplySelectionToDashboard()
+        {
             var abbr = !string.IsNullOrEmpty(GameState.SelectedTeamAbbr)
                        ? GameState.SelectedTeamAbbr
                        : PlayerPrefs.GetString("selected_team", "ATL");
 
-            Debug.Log($"[DashboardBootstrap] Showing roster for {abbr}");
-            panel.ShowRosterForTeam(abbr);
+            // Header
+            var header = Object.FindFirstObjectByType<DashboardHeaderBinder>(FindObjectsInactive.Include);
+            if (header) header.Apply(abbr);
+
+            // Roster panel (if present in Dashboard)
+            var panel = Object.FindFirstObjectByType<RosterPanelUI>(FindObjectsInactive.Include);
+            if (panel) panel.ShowRosterForTeam(abbr);
+
+            Debug.Log($"[DashboardBootstrap] Enforced selected team {abbr} on Dashboard.");
         }
     }
 }

--- a/Assets/Scripts/UI/DashboardHeaderBinder.cs
+++ b/Assets/Scripts/UI/DashboardHeaderBinder.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class DashboardHeaderBinder : MonoBehaviour
+{
+    [Header("Optional explicit refs (auto-wires if left empty)")]
+    [SerializeField] TMP_Text teamTitle;     // e.g., "Baltimore Knights (BAL)"
+    [SerializeField] Image    teamLogo;      // small crest/logo
+
+    Dictionary<string, TeamData> _teams;
+
+    public void Apply(string abbr)
+    {
+        abbr = (abbr ?? "").ToUpperInvariant();
+        EnsureTeamIndex();
+
+        // Find team data by abbr; if missing, display abbr only
+        TeamData t = null;
+        _teams?.TryGetValue(abbr, out t);
+
+        // Auto-wire if not set
+        if (!teamTitle) teamTitle = FindBestTitleText();
+        if (!teamLogo)  teamLogo  = FindBestLogoImage();
+
+        if (teamTitle)
+            teamTitle.text = t != null ? $"{t.city} {t.name} ({abbr})" : abbr;
+
+        if (teamLogo)
+        {
+            var spr = LogoService.Get(abbr);
+            teamLogo.enabled = spr != null;
+            teamLogo.sprite  = spr;
+            if (teamLogo) teamLogo.preserveAspect = true;
+        }
+
+        Debug.Log($"[HeaderBinder] Applied header for {abbr}");
+    }
+
+    // -------- helpers --------
+
+    void EnsureTeamIndex()
+    {
+        if (_teams != null) return;
+
+        var path = Path.Combine(Application.streamingAssetsPath, "teams.json");
+        if (!File.Exists(path)) { _teams = new(); return; }
+
+        var json = File.ReadAllText(path).TrimStart();
+        if (json.StartsWith("[")) json = "{\"teams\":" + json + "}";
+        var list = JsonUtility.FromJson<TeamDataList>(json)?.teams ?? new List<TeamData>();
+
+        _teams = new Dictionary<string, TeamData>(StringComparer.OrdinalIgnoreCase);
+        foreach (var t in list)
+            if (!string.IsNullOrEmpty(t.abbreviation))
+                _teams[t.abbreviation] = t;
+    }
+
+    TMP_Text FindBestTitleText()
+    {
+        // Prefer objects named like "TeamName", "Title", "HeaderTitle"
+        var cands = GetComponentsInChildren<TMP_Text>(true);
+        return cands.FirstOrDefault(x =>
+                 x.name.IndexOf("Team", StringComparison.OrdinalIgnoreCase) >= 0
+              || x.name.IndexOf("Title", StringComparison.OrdinalIgnoreCase) >= 0
+              || x.name.IndexOf("Header", StringComparison.OrdinalIgnoreCase) >= 0)
+            ?? cands.FirstOrDefault();
+    }
+
+    Image FindBestLogoImage()
+    {
+        // Prefer images near the header object with small square rects
+        var imgs = GetComponentsInChildren<Image>(true);
+        return imgs.OrderBy(i => Mathf.Abs(((RectTransform)i.transform).rect.width - ((RectTransform)i.transform).rect.height))
+                   .FirstOrDefault();
+    }
+}
+

--- a/Assets/Scripts/UI/DashboardHeaderBinder.cs.meta
+++ b/Assets/Scripts/UI/DashboardHeaderBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 63633211268f430c9a3313c4e6ffd0aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- bootstrap dashboard to enforce selected team's roster and header
- add header binder that auto-wires team title and logo

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f7e847c1883279d480ec8731d0e5e