### PR TITLE
feat: show confirmed team on dashboard

### DIFF
--- a/Assets/Scripts/UI/DashboardHeaderBinder.cs
+++ b/Assets/Scripts/UI/DashboardHeaderBinder.cs
@@ -10,7 +10,7 @@ public class DashboardHeaderBinder : MonoBehaviour
 {
     [Header("Optional explicit refs (auto-wires if left empty)")]
     [SerializeField] TMP_Text teamTitle;     // e.g., "Baltimore Knights (BAL)"
-    [SerializeField] Image    teamLogo;      // small crest/logo
+    [SerializeField] Image    teamLogo;      // crest/logo
 
     Dictionary<string, TeamData> _teams;
 
@@ -19,13 +19,11 @@ public class DashboardHeaderBinder : MonoBehaviour
         abbr = (abbr ?? "").ToUpperInvariant();
         EnsureTeamIndex();
 
-        // Find team data by abbr; if missing, display abbr only
-        TeamData t = null;
-        _teams?.TryGetValue(abbr, out t);
-
-        // Auto-wire if not set
+        // Auto-wire if not set: scan the whole UI under this GameObject
         if (!teamTitle) teamTitle = FindBestTitleText();
         if (!teamLogo)  teamLogo  = FindBestLogoImage();
+
+        _teams?.TryGetValue(abbr, out var t);
 
         if (teamTitle)
             teamTitle.text = t != null ? $"{t.city} {t.name} ({abbr})" : abbr;
@@ -35,7 +33,7 @@ public class DashboardHeaderBinder : MonoBehaviour
             var spr = LogoService.Get(abbr);
             teamLogo.enabled = spr != null;
             teamLogo.sprite  = spr;
-            if (teamLogo) teamLogo.preserveAspect = true;
+            teamLogo.preserveAspect = true;
         }
 
         Debug.Log($"[HeaderBinder] Applied header for {abbr}");
@@ -46,14 +44,14 @@ public class DashboardHeaderBinder : MonoBehaviour
     void EnsureTeamIndex()
     {
         if (_teams != null) return;
-
         var path = Path.Combine(Application.streamingAssetsPath, "teams.json");
-        if (!File.Exists(path)) { _teams = new(); return; }
-
-        var json = File.ReadAllText(path).TrimStart();
-        if (json.StartsWith("[")) json = "{\"teams\":" + json + "}";
-        var list = JsonUtility.FromJson<TeamDataList>(json)?.teams ?? new List<TeamData>();
-
+        var list = new List<TeamData>();
+        if (File.Exists(path))
+        {
+            var json = File.ReadAllText(path).TrimStart();
+            if (json.StartsWith("[")) json = "{\"teams\":" + json + "}";
+            list = JsonUtility.FromJson<TeamDataList>(json)?.teams ?? new List<TeamData>();
+        }
         _teams = new Dictionary<string, TeamData>(StringComparer.OrdinalIgnoreCase);
         foreach (var t in list)
             if (!string.IsNullOrEmpty(t.abbreviation))
@@ -62,21 +60,23 @@ public class DashboardHeaderBinder : MonoBehaviour
 
     TMP_Text FindBestTitleText()
     {
-        // Prefer objects named like "TeamName", "Title", "HeaderTitle"
-        var cands = GetComponentsInChildren<TMP_Text>(true);
-        return cands.FirstOrDefault(x =>
-                 x.name.IndexOf("Team", StringComparison.OrdinalIgnoreCase) >= 0
-              || x.name.IndexOf("Title", StringComparison.OrdinalIgnoreCase) >= 0
-              || x.name.IndexOf("Header", StringComparison.OrdinalIgnoreCase) >= 0)
-            ?? cands.FirstOrDefault();
+        // Prefer names containing Team/Title/Header; else largest TMP under this root.
+        var tmps = GetComponentsInChildren<TMP_Text>(true);
+        var byName = tmps.FirstOrDefault(x =>
+             x.name.IndexOf("Team", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             x.name.IndexOf("Title", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             x.name.IndexOf("Header", StringComparison.OrdinalIgnoreCase) >= 0);
+        if (byName) return byName;
+        return tmps.OrderByDescending(x => x.fontSize).FirstOrDefault();
     }
 
     Image FindBestLogoImage()
     {
-        // Prefer images near the header object with small square rects
-        var imgs = GetComponentsInChildren<Image>(true);
-        return imgs.OrderBy(i => Mathf.Abs(((RectTransform)i.transform).rect.width - ((RectTransform)i.transform).rect.height))
-                   .FirstOrDefault();
+        // Pick square-ish Image closest to the title if possible
+        var images = GetComponentsInChildren<Image>(true);
+        return images
+            .OrderBy(img => Mathf.Abs(((RectTransform)img.transform).rect.width - ((RectTransform)img.transform).rect.height))
+            .FirstOrDefault();
     }
 }
 


### PR DESCRIPTION
## Summary
- rework `DashboardHeaderBinder` to auto-wire UI and load team data/logo
- expand `DashboardBootstrap` to ensure header binder exists and display roster for selected team

## Testing
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689f7fd5b93c832795092a6a1546e4f2