### PR TITLE
fix: safely assign team data before use

### DIFF
--- a/Assets/Scripts/UI/DashboardHeaderBinder.cs
+++ b/Assets/Scripts/UI/DashboardHeaderBinder.cs
@@ -19,20 +19,23 @@ public class DashboardHeaderBinder : MonoBehaviour
         abbr = (abbr ?? "").ToUpperInvariant();
         EnsureTeamIndex();
 
-        // Auto-wire if not set: scan the whole UI under this GameObject
+        // Auto-wire if not set
         if (!teamTitle) teamTitle = FindBestTitleText();
         if (!teamLogo)  teamLogo  = FindBestLogoImage();
 
-        _teams?.TryGetValue(abbr, out var t);
+        // Safe lookup (no ?. with out var)
+        TeamData t = null;
+        if (_teams != null && _teams.TryGetValue(abbr, out var found))
+            t = found;
 
         if (teamTitle)
-            teamTitle.text = t != null ? $"{t.city} {t.name} ({abbr})" : abbr;
+            teamTitle.text = (t != null) ? $"{t.city} {t.name} ({abbr})" : abbr;
 
         if (teamLogo)
         {
             var spr = LogoService.Get(abbr);
-            teamLogo.enabled = spr != null;
-            teamLogo.sprite  = spr;
+            teamLogo.enabled     = spr != null;
+            teamLogo.sprite      = spr;
             teamLogo.preserveAspect = true;
         }
 


### PR DESCRIPTION
## Summary
- avoid definite assignment error by declaring team variable before lookup in `DashboardHeaderBinder.Apply`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f81a13e3c83278c823346de93920c