### PR TITLE
feat: disable roster watermarks and scene cleanup utility

### DIFF
--- a/Assets/Editor/DisableWatermarkInScene.cs
+++ b/Assets/Editor/DisableWatermarkInScene.cs
@@ -1,0 +1,41 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UI;
+
+public static class DisableWatermarkInScene
+{
+    [MenuItem("GridironGM/UI/Disable Watermarks In Open Scenes")]
+    public static void Run()
+    {
+        int disabled = 0, removed = 0;
+
+        foreach (var img in Object.FindObjectsByType<Image>(FindObjectsInactive.Include, FindObjectsSortMode.None))
+        {
+            if (!img) continue;
+            var n = img.name.ToLowerInvariant();
+            var looksLikeWatermark =
+                   n.Contains("watermark")
+                || (img.preserveAspect && !img.raycastTarget && img.color.a <= 0.1f);
+
+            if (!looksLikeWatermark) continue;
+
+            // If it’s a naked watermark object with only an Image, remove it; else just disable
+            var comps = img.GetComponents<Component>();
+            if (comps.Length <= 2) // Transform + Image
+            {
+                Object.DestroyImmediate(img.gameObject, true);
+                removed++;
+            }
+            else
+            {
+                img.enabled = false;
+                disabled++;
+            }
+        }
+
+        Debug.Log($"[DisableWatermarks] Disabled {disabled}, removed {removed} watermark image(s) in open scenes.");
+    }
+}
+#endif
+

--- a/Assets/Editor/DisableWatermarkInScene.cs.meta
+++ b/Assets/Editor/DisableWatermarkInScene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 77c2b966-73c8-4ec1-ac9a-f99c3ccdb626
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UI/RosterPanelUI.cs
+++ b/Assets/Scripts/UI/RosterPanelUI.cs
@@ -30,6 +30,10 @@ public class RosterPanelUI : MonoBehaviour
     [SerializeField] bool pinHeader = true;      // pinned (not scrolling). Set false for scrolling header.
     [SerializeField] bool showHeader = true;
 
+    [Header("Optional visuals")]
+    [SerializeField] bool enableWatermark = false;   // default OFF
+    Image _watermark;                                // cached if one exists
+
     Image _selectedBG;
     RectTransform _pinnedHeaderRT;   // created at runtime under the ScrollRect viewport
     float _headerHeightCached;
@@ -91,6 +95,10 @@ public class RosterPanelUI : MonoBehaviour
         }
 
         ReapplyRowWidths();
+        if (!enableWatermark)
+            ClearWatermark();
+        else
+            UpdateWatermark(abbr);
         Debug.Log($"[RosterPanel] Rendered {team.players.Count} players for {abbr}");
     }
 
@@ -268,6 +276,34 @@ public class RosterPanelUI : MonoBehaviour
             LockExact(name, nameW);
         }
         LayoutRebuilder.MarkLayoutForRebuild((RectTransform)content);
+    }
+
+    void UpdateWatermark(string abbr)
+    {
+        if (!enableWatermark) { ClearWatermark(); return; }
+
+        if (!_watermark)
+        {
+            var go = new GameObject("Watermark", typeof(Image));
+            var rt = go.GetComponent<RectTransform>();
+            rt.SetParent(transform, false);
+            rt.anchorMin = Vector2.zero; rt.anchorMax = Vector2.one; rt.sizeDelta = Vector2.zero;
+            _watermark = go.GetComponent<Image>();
+            _watermark.raycastTarget = false;
+            _watermark.preserveAspect = true;
+            _watermark.color = new Color(1f, 1f, 1f, 0.06f);
+        }
+        _watermark.enabled = true;
+        _watermark.sprite = LogoService.Get(abbr);
+    }
+
+    void ClearWatermark()
+    {
+        if (_watermark)
+            _watermark.enabled = false;
+        var stray = transform.Find("Watermark");
+        if (stray && stray != _watermark?.transform)
+            DestroyImmediate(stray.gameObject);
     }
 
     static TMP_Text FindTMP(Transform root, string childName)


### PR DESCRIPTION
## Summary
- add optional watermark toggle in RosterPanelUI and clear by default
- add editor utility to remove watermark images from open scenes

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa208eea0832793d079f9ca0b25ce