### PR TITLE
Improve dashboard header auto-wiring and runtime rebind

### DIFF
--- a/Assets/Editor/DashboardFixer.cs
+++ b/Assets/Editor/DashboardFixer.cs
@@ -68,15 +68,63 @@ public static class DashboardFixer
 
     static void AutoWire(DashboardSceneController ctrl, Transform root)
     {
-        // Heuristics: two biggest TMPs near the top; and a square-ish Image as the logo.
-        var tmps = root.GetComponentsInChildren<TextMeshProUGUI>(true);
-        var topHalf = tmps.Where(t => ((RectTransform)t.transform).anchoredPosition.y > -200f).ToArray();
-        var title1 = topHalf.OrderByDescending(t => t.fontSize).FirstOrDefault();
-        var title2 = topHalf.Where(t => t != title1).OrderByDescending(t => t.fontSize).FirstOrDefault();
+        bool IsTabLabel(TMP_Text t)
+        {
+            if (!t) return false;
+            string n = t.name.ToLowerInvariant();
+            string txt = (t.text ?? "").Trim().ToLowerInvariant();
+            if (t.GetComponentInParent<UnityEngine.UI.Selectable>() != null) return true; // under a button/tab
+            return
+                n.Contains("tab") || n.Contains("button") ||
+                n.Contains("roster") || n.Contains("depth") || n.Contains("schedule") ||
+                txt == "roster" || txt == "depth charts" || txt == "team schedule";
+        }
 
-        var imgs = root.GetComponentsInChildren<Image>(true);
-        var logo = imgs.OrderBy(i => Mathf.Abs(((RectTransform)i.transform).rect.width - ((RectTransform)i.transform).rect.height))
+        // Top-half TMPs, biggest first, skipping tab labels.
+        var tmps = root.GetComponentsInChildren<TextMeshProUGUI>(true)
+                       .Where(t => ((RectTransform)t.transform).anchoredPosition.y > -200f)
+                       .Where(t => !IsTabLabel(t))
+                       .OrderByDescending(t => t.fontSize)
+                       .ToList();
+
+        var title1 = tmps.FirstOrDefault();
+        var title2 = tmps.Skip(1).FirstOrDefault();
+
+        bool LooksLikeBadLogo(UnityEngine.UI.Image img)
+        {
+            if (!img) return true;
+            string n = img.name.ToLowerInvariant();
+            if (n.Contains("viewport") || n.Contains("mask") || n.Contains("content") ||
+                n.Contains("scroll") || n.Contains("background") || n.Contains("panel"))
+                return true;
+            var rt = (RectTransform)img.transform;
+            var r = rt.rect;
+            // prefer square-ish, not microscopic/huge
+            float squareness = Mathf.Abs(r.width - r.height);
+            if (r.width < 16f || r.height < 16f) return true;
+            return false;
+        }
+
+        // Prefer objects named logo/crest; otherwise nearest square-ish Image to title1.
+        var imgs = root.GetComponentsInChildren<UnityEngine.UI.Image>(true).ToList();
+        var namedLogo = imgs.FirstOrDefault(i =>
+            i.name.ToLowerInvariant().Contains("logo") || i.name.ToLowerInvariant().Contains("crest"));
+        UnityEngine.UI.Image logo = null;
+
+        if (namedLogo && !LooksLikeBadLogo(namedLogo)) logo = namedLogo;
+        else if (title1)
+        {
+            logo = imgs.Where(i => !LooksLikeBadLogo(i))
+                       .OrderBy(i =>
+                       {
+                           var rt = (RectTransform)i.transform;
+                           var r = rt.rect;
+                           float square = Mathf.Abs(r.width - r.height);
+                           float d = Vector3.Distance(i.transform.position, title1.transform.position);
+                           return square * 0.6f + d * 0.4f;
+                       })
                        .FirstOrDefault();
+        }
 
         var so = new SerializedObject(ctrl);
         so.FindProperty("titleLine1").objectReferenceValue = title1;


### PR DESCRIPTION
## Summary
- Refine DashboardFixer auto-wiring: skip tab labels and choose square-ish logos or nearest image.
- Add runtime header self-defense to DashboardSceneController, re-binding labels and logo if miswired.

## Testing
- `dotnet build 'Gridiron GM Alpha Build/Gridiron GM Alpha Build.sln'` *(fails: Microsoft.Unity.Analyzers.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb11ad8888327b3c1f361d66067be