### PR TITLE
Add season simulation and dashboard HUD

### DIFF
--- a/Assets/Editor/SeasonDevTools.cs
+++ b/Assets/Editor/SeasonDevTools.cs
@@ -1,0 +1,16 @@
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using System.IO;
+
+public static class SeasonDevTools
+{
+    [MenuItem("GridironGM/Dev/Clear Season Save")]
+    public static void Clear()
+    {
+        var p = Path.Combine(Application.persistentDataPath, "season.json");
+        if (File.Exists(p)) File.Delete(p);
+        Debug.Log("[Dev] Deleted season save.");
+    }
+}
+#endif

--- a/Assets/Scripts/Season/Models.cs
+++ b/Assets/Scripts/Season/Models.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace GG.Season
+{
+    [Serializable]
+    public struct TeamRecord { public int W, L, PF, PA; }
+
+    [Serializable]
+    public struct GameInfo { public int week; public string home, away; }
+
+    [Serializable]
+    public struct GameResult { public int week; public string home, away; public int homeScore, awayScore; }
+}

--- a/Assets/Scripts/Season/ScheduleService.cs
+++ b/Assets/Scripts/Season/ScheduleService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GG.Season
+{
+    public static class ScheduleService
+    {
+        public static List<GameInfo>[] Generate(List<string> teamAbbrs, int weeks = 14)
+        {
+            if (teamAbbrs == null) return Array.Empty<List<GameInfo>>();
+            var rng = new Random(SeasonState.SeasonStartSeed);
+            var teams = teamAbbrs.Where(t => !string.IsNullOrEmpty(t)).ToList();
+            if (teams.Count % 2 == 1) teams.Add("BYE");
+
+            // shuffle initial order
+            for (int i = teams.Count - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                (teams[i], teams[j]) = (teams[j], teams[i]);
+            }
+
+            int totalWeeks = Math.Min(weeks, teams.Count - 1);
+            var schedule = new List<GameInfo>[totalWeeks];
+            var rotation = new List<string>(teams);
+
+            for (int w = 0; w < totalWeeks; w++)
+            {
+                var games = new List<GameInfo>();
+                int half = rotation.Count / 2;
+                for (int i = 0; i < half; i++)
+                {
+                    var home = rotation[i];
+                    var away = rotation[rotation.Count - 1 - i];
+                    if (home == "BYE" || away == "BYE") continue;
+                    bool swap = ((i + w) % 2 == 0);
+                    var g = new GameInfo
+                    {
+                        week = w + 1,
+                        home = swap ? home : away,
+                        away = swap ? away : home
+                    };
+                    games.Add(g);
+                }
+                schedule[w] = games;
+
+                // rotate teams except first
+                var last = rotation[rotation.Count - 1];
+                rotation.RemoveAt(rotation.Count - 1);
+                rotation.Insert(1, last);
+            }
+            return schedule;
+        }
+    }
+}

--- a/Assets/Scripts/Season/SeasonState.cs
+++ b/Assets/Scripts/Season/SeasonState.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using UnityEngine;
+
+namespace GG.Season
+{
+    [Serializable]
+    public class SeasonState
+    {
+        public const int SeasonStartSeed = 20240101;
+
+        public int week;
+        public Dictionary<string, TeamRecord> records = new();
+        public List<GameInfo>[] scheduleByWeek;
+        public List<GameResult> results = new();
+
+        static string SavePath => Path.Combine(Application.persistentDataPath, "season.json");
+
+        public static SeasonState LoadOrCreate(string selectedAbbr)
+        {
+            try
+            {
+                if (File.Exists(SavePath))
+                {
+                    var json = File.ReadAllText(SavePath);
+                    var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+                    var loaded = JsonSerializer.Deserialize<SeasonState>(json, options);
+                    if (loaded != null)
+                        return loaded;
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[SeasonState] Load failed: {e}");
+            }
+
+            var teamAbbrs = global::LeagueRepository.GetTeams()
+                .Where(t => !string.IsNullOrEmpty(t.abbreviation))
+                .Select(t => t.abbreviation)
+                .ToList();
+
+            var state = new SeasonState();
+            state.week = 1;
+            state.records = teamAbbrs.ToDictionary(a => a, a => new TeamRecord());
+            state.scheduleByWeek = ScheduleService.Generate(teamAbbrs, 14);
+            state.Save();
+            return state;
+        }
+
+        public void Save()
+        {
+            try
+            {
+                var options = new JsonSerializerOptions { WriteIndented = true };
+                var json = JsonSerializer.Serialize(this, options);
+                File.WriteAllText(SavePath, json);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[SeasonState] Save failed: {e}");
+            }
+        }
+
+        public GameInfo? GetNextGame(string abbr)
+        {
+            if (string.IsNullOrEmpty(abbr) || scheduleByWeek == null) return null;
+            int w = week - 1;
+            if (w < 0 || w >= scheduleByWeek.Length) return null;
+            foreach (var g in scheduleByWeek[w])
+            {
+                bool played = results.Exists(r => r.week == g.week && r.home == g.home && r.away == g.away);
+                if (!played && (g.home == abbr || g.away == abbr))
+                    return g;
+            }
+            return null;
+        }
+
+        public void ApplyResult(GameResult r)
+        {
+            results.Add(r);
+
+            if (!records.ContainsKey(r.home)) records[r.home] = new TeamRecord();
+            if (!records.ContainsKey(r.away)) records[r.away] = new TeamRecord();
+
+            var home = records[r.home];
+            var away = records[r.away];
+
+            home.PF += r.homeScore;
+            home.PA += r.awayScore;
+            away.PF += r.awayScore;
+            away.PA += r.homeScore;
+
+            if (r.homeScore > r.awayScore) { home.W++; away.L++; }
+            else { away.W++; home.L++; }
+
+            records[r.home] = home;
+            records[r.away] = away;
+        }
+    }
+}

--- a/Assets/Scripts/Season/SimpleSim.cs
+++ b/Assets/Scripts/Season/SimpleSim.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace GG.Season
+{
+    public static class SimpleSim
+    {
+        public static GameResult Sim(GameInfo g, Func<string,int> teamOvrLookup, int seed)
+        {
+            int homeOvr = teamOvrLookup(g.home) + 2;
+            int awayOvr = teamOvrLookup(g.away);
+            int diff = homeOvr - awayOvr;
+            double winProb = 1.0 / (1.0 + Math.Exp(-diff / 6.0));
+            var rng = new Random(seed);
+            bool homeWins = rng.NextDouble() < winProb;
+            int homeBase = 20 + diff / 2;
+            int awayBase = 20 - diff / 2;
+            int homeScore = Math.Max(0, homeBase + rng.Next(-7, 8));
+            int awayScore = Math.Max(0, awayBase + rng.Next(-7, 8));
+            if (homeWins && homeScore <= awayScore) homeScore = awayScore + rng.Next(1,4);
+            if (!homeWins && awayScore <= homeScore) awayScore = homeScore + rng.Next(1,4);
+            return new GameResult { week = g.week, home = g.home, away = g.away, homeScore = homeScore, awayScore = awayScore };
+        }
+    }
+}

--- a/Assets/Scripts/UI/DashboardHUD.cs
+++ b/Assets/Scripts/UI/DashboardHUD.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using GG.Season;
+
+namespace GG.Game
+{
+    public class DashboardHUD : MonoBehaviour
+    {
+        [SerializeField] TMP_Text weekText;
+        [SerializeField] TMP_Text nextOpponentText;
+        [SerializeField] Button simButton;
+        [SerializeField] Button advanceButton;
+
+        SeasonState _season;
+
+        void Start()
+        {
+            _season = SeasonState.LoadOrCreate(GameState.SelectedTeamAbbr);
+            if (simButton) simButton.onClick.AddListener(OnClickSim);
+            if (advanceButton) advanceButton.onClick.AddListener(OnClickAdvance);
+            Refresh();
+        }
+
+        void Refresh()
+        {
+            if (weekText)
+            {
+                if (_season.week > _season.scheduleByWeek.Length) weekText.text = "Season Complete";
+                else weekText.text = $"Week {_season.week}";
+            }
+
+            if (nextOpponentText)
+            {
+                var next = _season.GetNextGame(GameState.SelectedTeamAbbr);
+                if (next == null) nextOpponentText.text = "Next: ---";
+                else
+                {
+                    bool home = next.Value.home == GameState.SelectedTeamAbbr;
+                    string opp = home ? next.Value.away : next.Value.home;
+                    nextOpponentText.text = $"Next: {opp} ({(home ? "H" : "A")})";
+                }
+            }
+        }
+
+        int LookupOvr(string abbr)
+        {
+            var roster = RosterService.LoadRosterFor(abbr);
+            if (roster == null || roster.players == null || roster.players.Count == 0) return 60;
+            return (int)roster.players.Average(p => p.overall);
+        }
+
+        public void OnClickSim()
+        {
+            var next = _season.GetNextGame(GameState.SelectedTeamAbbr);
+            if (next == null) return;
+            var result = SimpleSim.Sim(next.Value, LookupOvr, next.Value.week);
+            _season.ApplyResult(result);
+            _season.Save();
+            Debug.Log($"[DashboardHUD] Simmed {result.away} at {result.home}: {result.homeScore}-{result.awayScore}");
+            Refresh();
+        }
+
+        public void OnClickAdvance()
+        {
+            if (_season.week <= _season.scheduleByWeek.Length) _season.week++;
+            _season.Save();
+            Refresh();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement SeasonState with JSON persistence for week, records, schedule, and results
- Add ScheduleService for deterministic 14-week schedule generation
- Provide SimpleSim to produce basic game results from team overalls
- Add DashboardHUD to show next opponent and control sim/advance actions
- Include SeasonDevTools editor utility to clear saved season data

## Testing
- `dotnet test` *(fails: MSB1003 Specify a project or solution file)*


------
https://chatgpt.com/codex/tasks/task_e_689fb5103cb083278ac5d60fe7658fc3