### PR TITLE
Simplify dashboard HUD bootstrap and add season reset tool

### DIFF
--- a/Assets/Editor/SeasonTools.cs
+++ b/Assets/Editor/SeasonTools.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public static class SeasonTools
+{
+    [MenuItem("GridironGM/Dev/Clear Season Save")]
+    public static void ClearSeason()
+    {
+        var path = Path.Combine(Application.persistentDataPath, "season.json");
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+            Debug.Log($"[SeasonTools] Deleted season save: {path}");
+        }
+        else
+        {
+            Debug.Log("[SeasonTools] No season save found.");
+        }
+    }
+}

--- a/Assets/Editor/SeasonTools.cs.meta
+++ b/Assets/Editor/SeasonTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a57449865f194f7184bbca02305b4199
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- streamline DashboardHUD: load team list from StreamingAssets, always build schedule, and simplify sim/advance flow
- add SeasonTools editor utility to clear stored season data

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689fe2291c688327a47c569457e52d6d