### PR TITLE
Add core utilities and team provider with editor tools

### DIFF
--- a/Assets/Editor/GG.Editor.asmdef
+++ b/Assets/Editor/GG.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+  "name": "GG.Editor",
+  "references": [
+    "GUID:17d0f018-cd53-4c34-84c4-975204b28ae4"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Editor/GG.Editor.asmdef.meta
+++ b/Assets/Editor/GG.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fd9d21a-56c1-443e-ba2f-baf89a8bfc07
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Editor/PrefabTools.cs
+++ b/Assets/Editor/PrefabTools.cs
@@ -1,0 +1,23 @@
+#if UNITY_EDITOR
+using UnityEditor; using UnityEngine;
+public static class PrefabTools {
+  [MenuItem("GridironGM/Dev/Scan & Remove Missing Scripts")]
+  public static void RemoveMissing() {
+    var guids = AssetDatabase.FindAssets("t:Prefab");
+    int removed=0, scanned=0;
+    foreach (var g in guids) {
+      var path = AssetDatabase.GUIDToAssetPath(g);
+      var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path); if (!prefab) continue;
+      scanned++; removed += GameObjectUtility.RemoveMonoBehavioursWithMissingScript(prefab);
+    }
+    Debug.Log($"[GG] Prefabs scanned:{scanned}, missing scripts removed:{removed}");
+  }
+
+  [MenuItem("GridironGM/Dev/Clear Season Save")]
+  public static void ClearSeason() {
+    var p = GGPaths.Save(GGConventions.SeasonSaveFile);
+    if (System.IO.File.Exists(p)) { System.IO.File.Delete(p); Debug.Log($"[GG] Deleted {p}"); }
+    else Debug.Log("[GG] No season save found.");
+  }
+}
+#endif

--- a/Assets/Editor/PrefabTools.cs.meta
+++ b/Assets/Editor/PrefabTools.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 35151765-b797-4fe3-8dab-ffc483a46233
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/GGConventions.cs
+++ b/Assets/Scripts/Core/GGConventions.cs
@@ -1,0 +1,5 @@
+public static class GGConventions {
+  public const string SelectedTeamKey = "selected_team";
+  public const string SeasonSaveFile  = "season.json";
+  public const string TeamsJsonFile   = "teams.json";
+}

--- a/Assets/Scripts/Core/GGConventions.cs.meta
+++ b/Assets/Scripts/Core/GGConventions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 114967aa-4a09-4eec-a7e0-f1b4a671b771
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/GGLog.cs
+++ b/Assets/Scripts/Core/GGLog.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+public static class GGLog {
+  public static bool Verbose =
+#if GG_VERBOSE_LOGS
+    true;
+#else
+    false;
+#endif
+  public static void Info(string m){ if (Verbose) Debug.Log($"[GG] {m}"); }
+  public static void Warn(string m)=> Debug.LogWarning($"[GG] {m}");
+  public static void Error(string m)=> Debug.LogError($"[GG] {m}");
+}

--- a/Assets/Scripts/Core/GGLog.cs.meta
+++ b/Assets/Scripts/Core/GGLog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d927f7b-81bb-43fe-be2a-541570ca19c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/GGPaths.cs
+++ b/Assets/Scripts/Core/GGPaths.cs
@@ -1,0 +1,5 @@
+using System.IO; using UnityEngine;
+public static class GGPaths {
+  public static string Streaming(string file)=>Path.Combine(Application.streamingAssetsPath,file);
+  public static string Save(string file)=>Path.Combine(Application.persistentDataPath,file);
+}

--- a/Assets/Scripts/Core/GGPaths.cs.meta
+++ b/Assets/Scripts/Core/GGPaths.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dba7a9b2-622b-4604-81a0-e036aeca5266
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Core/TeamProvider.cs
+++ b/Assets/Scripts/Core/TeamProvider.cs
@@ -1,0 +1,77 @@
+using System; using System.Collections; using System.Collections.Generic;
+using System.IO; using System.Linq; using System.Reflection; using System.Text.RegularExpressions;
+
+public interface ITeamProvider { List<string> GetAllTeamAbbrs(); }
+
+public sealed class TeamProvider : ITeamProvider {
+  static readonly Regex AbbrProp = new Regex("\"abbr\"\\s*:\\s*\"([A-Za-z_-]+)\"", RegexOptions.IgnoreCase|RegexOptions.Compiled);
+  static readonly Regex KeyObj   = new Regex("^\\s*\"([A-Za-z0-9_-]{2,6})\"\\s*:\\s*\\{", RegexOptions.Multiline|RegexOptions.Compiled);
+
+  public List<string> GetAllTeamAbbrs() {
+    var a = FromJsonProps(); if (a.Count>1) { GGLog.Info($"TeamProvider props={a.Count}"); return Dedup(a); }
+    var b = FromJsonKeys();  if (b.Count>1) { GGLog.Info($"TeamProvider keys={b.Count}"); return Dedup(b); }
+    var c = FromRepo();      if (c.Count>1) { GGLog.Info($"TeamProvider repo={c.Count}"); return Dedup(c); }
+    GGLog.Warn("TeamProvider: no ABBRs discovered; falling back to selected only.");
+    return new List<string>();
+  }
+
+  List<string> FromJsonProps() {
+    try {
+      var p = GGPaths.Streaming(GGConventions.TeamsJsonFile); if (!File.Exists(p)) return new();
+      var txt = File.ReadAllText(p);
+      var ms = AbbrProp.Matches(txt);
+      var list = new List<string>(ms.Count); foreach (Match m in ms) list.Add(m.Groups[1].Value);
+      return list.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    } catch { return new(); }
+  }
+  List<string> FromJsonKeys() {
+    try {
+      var p = GGPaths.Streaming(GGConventions.TeamsJsonFile); if (!File.Exists(p)) return new();
+      var txt = File.ReadAllText(p);
+      var ms = KeyObj.Matches(txt);
+      var list = new List<string>(ms.Count);
+      foreach (Match m in ms) { var k=m.Groups[1].Value; if (!LikelyNonTeam(k)) list.Add(k); }
+      return list.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    } catch { return new(); }
+  }
+  static bool LikelyNonTeam(string k){
+    var s=k.ToLowerInvariant(); return s is "teams" or "meta" or "settings" or "logos" or "version";
+  }
+
+  List<string> FromRepo() {
+    try {
+      var t = AppDomain.CurrentDomain.GetAssemblies()
+        .SelectMany(a=>{ try { return a.GetTypes(); } catch { return Array.Empty<Type>(); } })
+        .FirstOrDefault(x=>x.Name=="LeagueRepository");
+      if (t==null) return new();
+      var inst = t.GetProperty("Instance",BindingFlags.Public|BindingFlags.NonPublic|BindingFlags.Static)?.GetValue(null)
+              ?? t.GetProperty("Current", BindingFlags.Public|BindingFlags.NonPublic|BindingFlags.Static)?.GetValue(null);
+      var flags = BindingFlags.Public|BindingFlags.NonPublic|((inst==null)?BindingFlags.Static:BindingFlags.Instance);
+      var sink = new List<string>();
+      foreach (var m in t.GetMembers(flags)) {
+        object val=null; try {
+          if (m is PropertyInfo p && p.CanRead) val=p.GetValue(inst);
+          else if (m is FieldInfo f) val=f.GetValue(inst);
+        } catch { }
+        if (val is IDictionary dict) foreach (var k in dict.Keys) if (k is string s && LooksLikeAbbr(s)) sink.Add(s);
+        if (val is IEnumerable seq && val is not string)
+          foreach (var it in seq) { var a=ExtractAbbr(it); if (!string.IsNullOrEmpty(a)) sink.Add(a); }
+      }
+      return sink.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+    } catch { return new(); }
+  }
+
+  static string ExtractAbbr(object o){ if (o==null) return null; var t=o.GetType();
+    var p=t.GetProperty("abbr")??t.GetProperty("Abbr")??t.GetProperty("id")??t.GetProperty("ID");
+    if (p!=null){ var v=p.GetValue(o)?.ToString(); if (LooksLikeAbbr(v)) return v; }
+    var f=t.GetField("abbr")??t.GetField("Abbr")??t.GetField("id")??t.GetField("ID");
+    if (f!=null){ var v=f.GetValue(o)?.ToString(); if (LooksLikeAbbr(v)) return v; }
+    return null; }
+
+  static bool LooksLikeAbbr(string s){ if (string.IsNullOrWhiteSpace(s)) return false; s=s.Trim();
+    if (s.Length<2||s.Length>6) return false; int letters=0;
+    foreach (var c in s){ if (char.IsLetter(c)) letters++; else if (c!='-'&&c!='_') return false; }
+    return letters>=2; }
+
+  static List<string> Dedup(List<string> x)=>x.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+}

--- a/Assets/Scripts/Core/TeamProvider.cs.meta
+++ b/Assets/Scripts/Core/TeamProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7568befb-909d-443b-93a2-6da896305af5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/GG.Runtime.asmdef
+++ b/Assets/Scripts/GG.Runtime.asmdef
@@ -1,0 +1,13 @@
+{
+  "name": "GG.Runtime",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}

--- a/Assets/Scripts/GG.Runtime.asmdef.meta
+++ b/Assets/Scripts/GG.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 17d0f018-cd53-4c34-84c4-975204b28ae4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e44272b4-8aa8-4b15-8caf-8984131d41fa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/PlayMode.meta
+++ b/Assets/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a219692-c902-4936-a769-5ab52030276b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/PlayMode/TeamProviderTests.cs
+++ b/Assets/Tests/PlayMode/TeamProviderTests.cs
@@ -1,0 +1,9 @@
+#if UNITY_INCLUDE_TESTS
+using NUnit.Framework;
+public class TeamProviderTests {
+  [Test] public void provider_returns_multiple() {
+    var n = new TeamProvider().GetAllTeamAbbrs().Count;
+    Assert.GreaterOrEqual(n, 2, "Need >=2 teams for schedule.");
+  }
+}
+#endif

--- a/Assets/Tests/PlayMode/TeamProviderTests.cs.meta
+++ b/Assets/Tests/PlayMode/TeamProviderTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4938e306-727d-4138-a5c7-edf2a042670e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add GGLog, GGPaths, and GGConventions utilities
- implement TeamProvider for discovering team abbreviations
- add PrefabTools editor menu and play mode test
- add assembly definitions for runtime and editor code

## Testing
- ❌ `dotnet test` (dotnet: command not found)

------
https://chatgpt.com/codex/tasks/task_e_689ff3695bb08327a2e8face3dd8f212