### PR TITLE
Add contract bridge and cap view

### DIFF
--- a/Assets/Scripts/Bridge/Dto/Contracts.cs
+++ b/Assets/Scripts/Bridge/Dto/Contracts.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace System.Text.Json.Serialization {
+  [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+  internal sealed class JsonPropertyNameAttribute : Attribute {
+    public JsonPropertyNameAttribute(string n) { }
+  }
+  [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+  internal sealed class JsonExtensionDataAttribute : Attribute { }
+}
+
+[Serializable]
+public class ContractYearTerm {
+  [JsonPropertyName("year")]
+  public int Year;
+  [JsonPropertyName("base")]
+  public long Base;
+  [JsonPropertyName("signingProrated")]
+  public long SigningProrated;
+  [JsonPropertyName("rosterBonus")]
+  public long RosterBonus;
+  [JsonPropertyName("workoutBonus")]
+  public long WorkoutBonus;
+  [JsonPropertyName("guaranteedBase")]
+  public long GuaranteedBase;
+}
+
+[Serializable]
+public class Guarantee {
+  [JsonPropertyName("type")]
+  public string Type;
+  [JsonPropertyName("throughYear")]
+  public int ThroughYear;
+}
+
+[Serializable]
+public class Incentive {
+  [JsonPropertyName("type")]
+  public string Type;
+  [JsonPropertyName("amount")]
+  public long Amount;
+  [JsonPropertyName("metric")]
+  public string Metric;
+  [JsonPropertyName("threshold")]
+  public string Threshold;
+}
+
+[Serializable]
+public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ISerializationCallbackReceiver {
+  [SerializeField] List<TKey> keys = new List<TKey>();
+  [SerializeField] List<TValue> values = new List<TValue>();
+
+  public void OnBeforeSerialize() {
+    keys.Clear(); values.Clear();
+    foreach (var kv in this) { keys.Add(kv.Key); values.Add(kv.Value); }
+  }
+
+  public void OnAfterDeserialize() {
+    this.Clear();
+    for (int i = 0; i < Math.Min(keys.Count, values.Count); i++) this[keys[i]] = values[i];
+  }
+}
+
+[Serializable]
+public class ContractDTO {
+  [JsonPropertyName("apiVersion")]
+  public string ApiVersion;
+  [JsonPropertyName("startYear")]
+  public int StartYear;
+  [JsonPropertyName("endYear")]
+  public int EndYear;
+  [JsonPropertyName("terms")]
+  public List<ContractYearTerm> Terms;
+  [JsonPropertyName("guarantees")]
+  public List<Guarantee> Guarantees;
+  [JsonPropertyName("incentives")]
+  public List<Incentive> Incentives;
+  [JsonPropertyName("flags")]
+  public SerializableDictionary<string, bool> Flags;
+  [JsonPropertyName("notes")]
+  public List<string> Notes;
+  [JsonExtensionData]
+  public SerializableDictionary<string, string> Extra;
+}

--- a/Assets/Scripts/Bridge/Validation/ContractValidator.cs
+++ b/Assets/Scripts/Bridge/Validation/ContractValidator.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+public static class ContractValidator {
+  public static void Validate(ContractDTO c){
+    if (c == null) throw new GGDataException("GG2001", "Null contract payload");
+    if (c.ApiVersion != "gg.v1") throw new GGDataException("GG2002", $"Version {c.ApiVersion} not supported");
+    if (c.Terms == null || c.Terms.Count == 0) throw new GGDataException("GG2003", "Missing terms[]");
+    foreach (var t in c.Terms){
+      if (t.Year < 2000 || t.Year > 2100)
+        throw new GGDataException("GG2003", $"Term year out of range {t.Year}");
+      if (t.Base < 0 || t.SigningProrated < 0 || t.RosterBonus < 0 || t.WorkoutBonus < 0 || t.GuaranteedBase < 0)
+        throw new GGDataException("GG2003", "Negative term amounts");
+    }
+  }
+
+  public class GGDataException : Exception {
+    public string Code { get; private set; }
+    public GGDataException(string code, string msg) : base(msg) { Code = code; }
+  }
+}

--- a/Assets/Scripts/Bridge/Validation/DataIO.cs
+++ b/Assets/Scripts/Bridge/Validation/DataIO.cs
@@ -1,0 +1,17 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+public static class DataIO {
+  public static T LoadJson<T>(string relativePath){
+    var path = GGPaths.Project(relativePath);
+    GGLog.Info($"LoadJson {path}");
+    try {
+      var txt = File.ReadAllText(path);
+      return JsonUtility.FromJson<T>(txt);
+    } catch (Exception ex) {
+      GGLog.Error($"LoadJson failed: {ex.Message}");
+      throw;
+    }
+  }
+}

--- a/Assets/Scripts/Core/GGLog.cs
+++ b/Assets/Scripts/Core/GGLog.cs
@@ -1,4 +1,6 @@
+using System.IO;
 using UnityEngine;
+
 public static class GGLog {
   public static bool Verbose =
 #if GG_VERBOSE_LOGS
@@ -6,7 +8,17 @@ public static class GGLog {
 #else
     false;
 #endif
-  public static void Info(string m){ if (Verbose) Debug.Log($"[GG] {m}"); }
-  public static void Warn(string m)=> Debug.LogWarning($"[GG] {m}");
-  public static void Error(string m)=> Debug.LogError($"[GG] {m}");
+
+  static string logFile;
+  static string LogFile { get { if (logFile==null) logFile = GGPaths.Save("gg_log.txt"); return logFile; } }
+
+  static void Write(string level, string msg){
+#if !UNITY_EDITOR
+    try { File.AppendAllText(LogFile, $"[{level}] {msg}\n"); } catch { }
+#endif
+  }
+
+  public static void Info(string m){ if (Verbose) Debug.Log($"[GG] {m}"); Write("I", m); }
+  public static void Warn(string m){ Debug.LogWarning($"[GG] {m}"); Write("W", m); }
+  public static void Error(string m){ Debug.LogError($"[GG] {m}"); Write("E", m); }
 }

--- a/Assets/Scripts/Core/GGPaths.cs
+++ b/Assets/Scripts/Core/GGPaths.cs
@@ -2,4 +2,5 @@ using System.IO; using UnityEngine;
 public static class GGPaths {
   public static string Streaming(string file)=>Path.Combine(Application.streamingAssetsPath,file);
   public static string Save(string file)=>Path.Combine(Application.persistentDataPath,file);
+  public static string Project(string file)=>Path.GetFullPath(Path.Combine(Application.dataPath,"..",file));
 }

--- a/Assets/Scripts/Infra/SceneRoutes.cs
+++ b/Assets/Scripts/Infra/SceneRoutes.cs
@@ -1,0 +1,5 @@
+public static class SceneRoutes {
+  public const string MainMenu  = "MainMenu";
+  public const string TeamSelect = "TeamSelect";
+  public const string Dashboard  = "Dashboard";
+}

--- a/Assets/Scripts/UI/Cap/ContractDetailPanel.cs
+++ b/Assets/Scripts/UI/Cap/ContractDetailPanel.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+internal class ContractDetailPanel : MonoBehaviour {
+  [SerializeField] TMP_Text content;
+  [SerializeField] TMP_Text errorBanner;
+
+  public ContractDTO Contract;
+  public int Year;
+
+  void OnEnable(){
+    if (content == null) content = gameObject.AddComponent<TMP_Text>();
+    Render();
+  }
+
+  void Render(){
+    if (Contract == null){ ShowError("No contract"); return; }
+    try {
+      ContractValidator.Validate(Contract);
+    } catch (ContractValidator.GGDataException ex){
+      ShowError($"Data version mismatch ({ex.Code})");
+      return;
+    }
+    var rows = new List<string>();
+    foreach (var t in Contract.Terms){
+      if (t.Year == Year || t.Year == Year + 1){
+        rows.Add($"{t.Year}: {FormatMoney(t.Base)} base + {FormatMoney(t.SigningProrated)} signing");
+      }
+    }
+    if (rows.Count == 0) ShowError("No terms found"); else content.text = string.Join("\n", rows);
+  }
+
+  void ShowError(string msg){
+    if (errorBanner == null){
+      errorBanner = new GameObject("Error", typeof(RectTransform), typeof(TMP_Text)).GetComponent<TMP_Text>();
+      errorBanner.transform.SetParent(transform,false);
+      var r = errorBanner.GetComponent<RectTransform>();
+      r.anchorMin = new Vector2(0,1); r.anchorMax = new Vector2(1,1); r.pivot = new Vector2(0.5f,1); r.offsetMin = new Vector2(0,-30); r.offsetMax = new Vector2(0,0);
+      errorBanner.color = Color.red;
+    }
+    errorBanner.text = msg; errorBanner.gameObject.SetActive(true);
+  }
+
+  string FormatMoney(long v)=>"$" + (v/1_000_000f).ToString("0.0") + "M";
+}

--- a/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+internal class TeamCapView : MonoBehaviour {
+  [SerializeField] string teamAbbr;
+  [SerializeField] int year;
+  [SerializeField] RectTransform contentRoot;
+  [SerializeField] TMP_Text rowTemplate;
+  [SerializeField] TMP_Text errorBanner;
+
+  public string TeamAbbr { get => teamAbbr; set => teamAbbr = value; }
+  public int Year { get => year; set => year = value; }
+
+  void OnEnable(){
+    if (contentRoot == null) BuildRuntimeUI();
+    try {
+      var dto = DataIO.LoadJson<CapsheetDTO>($"data/cap/capsheet_{Year}.json");
+      if (dto.ApiVersion != "gg.v1") throw new ContractValidator.GGDataException("GG2002", $"Version {dto.ApiVersion} not supported");
+      Render(dto);
+    } catch (ContractValidator.GGDataException ex) {
+      GGLog.Warn("TeamCapView GGDataException " + ex.Code);
+      ShowError($"Data version mismatch ({ex.Code})");
+    } catch (IOException) {
+      ShowError("Capsheet missing");
+    } catch (Exception ex) {
+      GGLog.Error("TeamCapView " + ex.Message);
+      ShowError("Capsheet missing");
+    }
+  }
+
+  void BuildRuntimeUI(){
+    var scroll = new GameObject("ScrollView", typeof(RectTransform), typeof(ScrollRect));
+    scroll.transform.SetParent(transform,false);
+    var srect = scroll.GetComponent<RectTransform>();
+    srect.anchorMin = Vector2.zero; srect.anchorMax = Vector2.one; srect.offsetMin = Vector2.zero; srect.offsetMax = Vector2.zero;
+
+    var viewport = new GameObject("Viewport", typeof(RectTransform), typeof(Mask), typeof(Image));
+    viewport.transform.SetParent(scroll.transform,false);
+    var vrect = viewport.GetComponent<RectTransform>();
+    vrect.anchorMin = Vector2.zero; vrect.anchorMax = Vector2.one; vrect.offsetMin = Vector2.zero; vrect.offsetMax = Vector2.zero;
+    viewport.GetComponent<Image>().color = Color.clear;
+
+    var content = new GameObject("Content", typeof(RectTransform), typeof(VerticalLayoutGroup));
+    content.transform.SetParent(viewport.transform,false);
+    contentRoot = content.GetComponent<RectTransform>();
+
+    var sr = scroll.GetComponent<ScrollRect>();
+    sr.viewport = vrect; sr.content = contentRoot;
+
+    rowTemplate = new GameObject("Row", typeof(RectTransform), typeof(TMP_Text)).GetComponent<TMP_Text>();
+    rowTemplate.transform.SetParent(contentRoot,false);
+    rowTemplate.gameObject.SetActive(false);
+
+    errorBanner = new GameObject("Error", typeof(RectTransform), typeof(TMP_Text)).GetComponent<TMP_Text>();
+    errorBanner.transform.SetParent(transform,false);
+    var brect = errorBanner.GetComponent<RectTransform>();
+    brect.anchorMin = new Vector2(0,1); brect.anchorMax = new Vector2(1,1); brect.pivot = new Vector2(0.5f,1);
+    brect.offsetMin = new Vector2(0,-30); brect.offsetMax = new Vector2(0,0);
+    errorBanner.color = Color.red;
+    errorBanner.gameObject.SetActive(false);
+  }
+
+  void Render(CapsheetDTO dto){
+    foreach (Transform t in contentRoot){ if (t != rowTemplate.transform) Destroy(t.gameObject); }
+    errorBanner.gameObject.SetActive(false);
+    foreach (var r in dto.Rows){
+      if (!string.Equals(r.TeamAbbr, TeamAbbr, StringComparison.OrdinalIgnoreCase)) continue;
+      var row = Instantiate(rowTemplate, contentRoot);
+      row.gameObject.SetActive(true);
+      row.text = $"{r.PlayerName} {FormatMoney(r.CapHit)}";
+    }
+  }
+
+  void ShowError(string msg){
+    if (errorBanner == null) return;
+    errorBanner.text = msg;
+    errorBanner.gameObject.SetActive(true);
+  }
+
+  string FormatMoney(long v) => "$" + (v/1_000_000f).ToString("0.0") + "M";
+
+  [Serializable]
+  class CapsheetDTO {
+    public string ApiVersion;
+    public List<Row> Rows;
+    public Totals Totals;
+  }
+  [Serializable]
+  class Row {
+    public string PlayerName;
+    public string TeamAbbr;
+    public int Year;
+    public long Base;
+    public long SigningProrated;
+    public long RosterBonus;
+    public long WorkoutBonus;
+    public long CapHit;
+    public long DeadCap;
+  }
+  [Serializable]
+  class Totals {
+    public long CapHit;
+    public long DeadCap;
+  }
+}


### PR DESCRIPTION
## Summary
- expand GGLog with file output
- add data loading and contract DTOs
- implement contract validator and cap view UI

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0021ee3fc832790c9c1604d80c14d