### PR TITLE
Add data path helpers and update validation utilities

### DIFF
--- a/Assets/Scripts/Bridge/Validation/ContractValidator.cs
+++ b/Assets/Scripts/Bridge/Validation/ContractValidator.cs
@@ -8,10 +8,8 @@ namespace GG.Bridge.Validation
         public static void Validate(ContractDTO c)
         {
             if (c == null) throw new GGDataException("GG2001", "Null contract payload");
-            if (c.ApiVersion != "gg.v1")
-                throw new GGDataException("GG2002", $"Version {c.ApiVersion} not supported");
-            if (c.Terms == null || c.Terms.Count == 0)
-                throw new GGDataException("GG2003", "Missing terms[]");
+            if (c.ApiVersion != "gg.v1") throw new GGDataException("GG2002", $"Version {c.ApiVersion} not supported");
+            if (c.Terms == null || c.Terms.Count == 0) throw new GGDataException("GG2003", "Missing terms[]");
 
             foreach (var t in c.Terms)
             {

--- a/Assets/Scripts/Bridge/Validation/DataIO.cs
+++ b/Assets/Scripts/Bridge/Validation/DataIO.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Newtonsoft.Json;
 using GG.Infra;
@@ -6,9 +7,33 @@ namespace GG.Bridge.Validation
 {
     internal static class DataIO
     {
-        public static T LoadJson<T>(string relativePath)
+        /// <summary>
+        /// Loads JSON either from:
+        ///  - a path rooted at /data (e.g., "data/cap/capsheet_2026.json" or "/data/…"), or
+        ///  - a relative path within /data (e.g., "cap/capsheet_2026.json"), or
+        ///  - an absolute path.
+        /// </summary>
+        public static T LoadJson<T>(string path)
         {
-            var abs = GGPaths.Project(relativePath);
+            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Empty path");
+
+            string abs;
+            var norm = path.Replace("\\", "/");
+
+            if (Path.IsPathRooted(path))
+            {
+                abs = path;
+            }
+            else if (norm.StartsWith("data/", StringComparison.OrdinalIgnoreCase) ||
+                     norm.StartsWith("/data/", StringComparison.OrdinalIgnoreCase))
+            {
+                abs = Path.GetFullPath(Path.Combine(GGPaths.ProjectRoot, norm.TrimStart('/')));
+            }
+            else
+            {
+                abs = GGPaths.Data(norm);
+            }
+
             var json = File.ReadAllText(abs);
 
             var settings = new JsonSerializerSettings
@@ -19,7 +44,7 @@ namespace GG.Bridge.Validation
             };
 
             var obj = JsonConvert.DeserializeObject<T>(json, settings);
-            GGLog.Info($"Loaded JSON: {abs}");
+            GG.Infra.GGLog.Info($"Loaded JSON: {abs}");
             return obj;
         }
     }

--- a/Assets/Scripts/Infra/GGLog.cs
+++ b/Assets/Scripts/Infra/GGLog.cs
@@ -8,7 +8,7 @@ namespace GG.Infra
     public static class GGLog
     {
         private static readonly object _lock = new object();
-        private static string LogPath => GGPaths.Save("gg_log.txt");
+        private static string LogPath => global::GGPaths.Save("gg_log.txt");
 
         public static void Info(string msg)  => Write("INFO", msg, null);
         public static void Warn(string msg)  => Write("WARN", msg, null);

--- a/Assets/Scripts/Infra/GGPaths.cs
+++ b/Assets/Scripts/Infra/GGPaths.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using UnityEngine;
+
+namespace GG.Infra
+{
+    /// <summary>Project path helpers. Treats /data as a sibling of Assets/.</summary>
+    public static class GGPaths
+    {
+        public static string ProjectRoot =>
+            Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
+
+        public static string DataRoot()
+        {
+            var p = Path.Combine(ProjectRoot, "data");
+            if (!Directory.Exists(p)) Directory.CreateDirectory(p);
+            return p;
+        }
+
+        /// <summary>Returns an absolute path inside /data, creating parent dirs if needed.</summary>
+        public static string Data(string relative)
+        {
+            var abs = Path.GetFullPath(Path.Combine(DataRoot(), relative.TrimStart('/', '\\')));
+            var dir = Path.GetDirectoryName(abs);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+            return abs;
+        }
+
+        public static string CapSheetFile(int year) => Data(Path.Combine("cap", $"capsheet_{year}.json"));
+    }
+}

--- a/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -1,109 +1,77 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using TMPro;
 using UnityEngine;
-using UnityEngine.UI;
+using GG.Infra;
+using GG.Bridge.Validation;
 
-internal class TeamCapView : MonoBehaviour {
-  [SerializeField] string teamAbbr;
-  [SerializeField] int year;
-  [SerializeField] RectTransform contentRoot;
-  [SerializeField] TMP_Text rowTemplate;
-  [SerializeField] TMP_Text errorBanner;
-
-  public string TeamAbbr { get => teamAbbr; set => teamAbbr = value; }
-  public int Year { get => year; set => year = value; }
-
-  void OnEnable(){
-    if (contentRoot == null) BuildRuntimeUI();
-    try {
-      var dto = DataIO.LoadJson<CapsheetDTO>($"data/cap/capsheet_{Year}.json");
-      if (dto.ApiVersion != "gg.v1") throw new ContractValidator.GGDataException("GG2002", $"Version {dto.ApiVersion} not supported");
-      Render(dto);
-    } catch (ContractValidator.GGDataException ex) {
-      GGLog.Warn("TeamCapView GGDataException " + ex.Code);
-      ShowError($"Data version mismatch ({ex.Code})");
-    } catch (IOException) {
-      ShowError("Capsheet missing");
-    } catch (Exception ex) {
-      GGLog.Error("TeamCapView " + ex.Message);
-      ShowError("Capsheet missing");
+namespace GG.UI.Cap
+{
+    [Serializable]
+    public class CapRow
+    {
+        public string PlayerName;
+        public string TeamAbbr;
+        public int Year;
+        public long Base;
+        public long SigningProrated;
+        public long RosterBonus;
+        public long WorkoutBonus;
+        public long CapHit;
+        public long DeadCap;
     }
-  }
 
-  void BuildRuntimeUI(){
-    var scroll = new GameObject("ScrollView", typeof(RectTransform), typeof(ScrollRect));
-    scroll.transform.SetParent(transform,false);
-    var srect = scroll.GetComponent<RectTransform>();
-    srect.anchorMin = Vector2.zero; srect.anchorMax = Vector2.one; srect.offsetMin = Vector2.zero; srect.offsetMax = Vector2.zero;
-
-    var viewport = new GameObject("Viewport", typeof(RectTransform), typeof(Mask), typeof(Image));
-    viewport.transform.SetParent(scroll.transform,false);
-    var vrect = viewport.GetComponent<RectTransform>();
-    vrect.anchorMin = Vector2.zero; vrect.anchorMax = Vector2.one; vrect.offsetMin = Vector2.zero; vrect.offsetMax = Vector2.zero;
-    viewport.GetComponent<Image>().color = Color.clear;
-
-    var content = new GameObject("Content", typeof(RectTransform), typeof(VerticalLayoutGroup));
-    content.transform.SetParent(viewport.transform,false);
-    contentRoot = content.GetComponent<RectTransform>();
-
-    var sr = scroll.GetComponent<ScrollRect>();
-    sr.viewport = vrect; sr.content = contentRoot;
-
-    rowTemplate = new GameObject("Row", typeof(RectTransform), typeof(TMP_Text)).GetComponent<TMP_Text>();
-    rowTemplate.transform.SetParent(contentRoot,false);
-    rowTemplate.gameObject.SetActive(false);
-
-    errorBanner = new GameObject("Error", typeof(RectTransform), typeof(TMP_Text)).GetComponent<TMP_Text>();
-    errorBanner.transform.SetParent(transform,false);
-    var brect = errorBanner.GetComponent<RectTransform>();
-    brect.anchorMin = new Vector2(0,1); brect.anchorMax = new Vector2(1,1); brect.pivot = new Vector2(0.5f,1);
-    brect.offsetMin = new Vector2(0,-30); brect.offsetMax = new Vector2(0,0);
-    errorBanner.color = Color.red;
-    errorBanner.gameObject.SetActive(false);
-  }
-
-  void Render(CapsheetDTO dto){
-    foreach (Transform t in contentRoot){ if (t != rowTemplate.transform) Destroy(t.gameObject); }
-    errorBanner.gameObject.SetActive(false);
-    foreach (var r in dto.Rows){
-      if (!string.Equals(r.TeamAbbr, TeamAbbr, StringComparison.OrdinalIgnoreCase)) continue;
-      var row = Instantiate(rowTemplate, contentRoot);
-      row.gameObject.SetActive(true);
-      row.text = $"{r.PlayerName} {FormatMoney(r.CapHit)}";
+    [Serializable]
+    public class CapSheet
+    {
+        public List<CapRow> Rows = new();
+        public long TeamTotalCapHit;
+        public long TeamTotalDeadCap;
     }
-  }
 
-  void ShowError(string msg){
-    if (errorBanner == null) return;
-    errorBanner.text = msg;
-    errorBanner.gameObject.SetActive(true);
-  }
+    public class TeamCapView : MonoBehaviour
+    {
+        [SerializeField] private TMP_Text content;
+        public string TeamAbbr;
+        public int Year;
 
-  string FormatMoney(long v) => "$" + (v/1_000_000f).ToString("0.0") + "M";
+        void OnEnable()
+        {
+            if (!content)
+            {
+                var go = new GameObject("CapText", typeof(RectTransform));
+                go.transform.SetParent(transform, false);
+                content = go.AddComponent<TMP_Text>();
+            }
+            Render();
+        }
 
-  [Serializable]
-  class CapsheetDTO {
-    public string ApiVersion;
-    public List<Row> Rows;
-    public Totals Totals;
-  }
-  [Serializable]
-  class Row {
-    public string PlayerName;
-    public string TeamAbbr;
-    public int Year;
-    public long Base;
-    public long SigningProrated;
-    public long RosterBonus;
-    public long WorkoutBonus;
-    public long CapHit;
-    public long DeadCap;
-  }
-  [Serializable]
-  class Totals {
-    public long CapHit;
-    public long DeadCap;
-  }
+        void Render()
+        {
+            try
+            {
+                // Support either "cap/capsheet_YYYY.json" or "/data/cap/capsheet_YYYY.json"
+                var relative = $"cap/capsheet_{Year}.json";
+                var sheet = DataIO.LoadJson<CapSheet>(relative);
+
+                var list = new List<string>();
+                foreach (var r in sheet.Rows)
+                {
+                    if (!string.IsNullOrEmpty(TeamAbbr) && !string.Equals(r.TeamAbbr, TeamAbbr, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    list.Add($"{r.PlayerName,-20}  {Fmt(r.CapHit)}  (dead {Fmt(r.DeadCap)})");
+                }
+
+                if (list.Count == 0) content.text = "No cap rows found.";
+                else content.text = string.Join("\n", list);
+            }
+            catch (Exception ex)
+            {
+                GGLog.Error("Failed to load capsheet", ex);
+                content.text = "Cap sheet not available.";
+            }
+        }
+
+        static string Fmt(long v) => "$" + (v / 1_000_000f).ToString("0.0") + "M";
+    }
 }


### PR DESCRIPTION
## Summary
- add GG.Infra.GGPaths helper for project and data paths
- rework DataIO and ContractValidator under GG.Bridge.Validation namespace
- simplify TeamCapView to use new JSON loader and log errors

## Testing
- `dotnet build` *(fails: Specify a project or solution file. The current working directory does not contain a project or solution file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a00b4849b4832786aaaeeca63eac2d