### PR TITLE
refactor: self-contained path resolution

### DIFF
--- a/Assets/Scripts/Bridge/Validation/DataIO.cs
+++ b/Assets/Scripts/Bridge/Validation/DataIO.cs
@@ -1,24 +1,35 @@
 using System;
 using System.IO;
 using Newtonsoft.Json;
-using GG.Infra;
+using GG.Infra; // for GGLog
 
 namespace GG.Bridge.Validation
 {
     internal static class DataIO
     {
+        private static string ProjectRoot =>
+            Path.GetFullPath(Path.Combine(UnityEngine.Application.dataPath, ".."));
+
+        private static string EnsureDataRoot()
+        {
+            var p = Path.Combine(ProjectRoot, "data");
+            if (!Directory.Exists(p)) Directory.CreateDirectory(p);
+            return p;
+        }
+
         /// <summary>
-        /// Loads JSON either from:
-        ///  - a path rooted at /data (e.g., "data/cap/capsheet_2026.json" or "/data/…"), or
-        ///  - a relative path within /data (e.g., "cap/capsheet_2026.json"), or
-        ///  - an absolute path.
+        /// Loads JSON from:
+        ///  - absolute path, or
+        ///  - "data/..." or "/data/..." under the project root, or
+        ///  - relative path under the "/data" folder (e.g., "cap/capsheet_2026.json").
         /// </summary>
         public static T LoadJson<T>(string path)
         {
-            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Empty path");
+            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Empty path", nameof(path));
 
             string abs;
             var norm = path.Replace("\\", "/");
+            var dataRoot = EnsureDataRoot();
 
             if (Path.IsPathRooted(path))
             {
@@ -27,11 +38,11 @@ namespace GG.Bridge.Validation
             else if (norm.StartsWith("data/", StringComparison.OrdinalIgnoreCase) ||
                      norm.StartsWith("/data/", StringComparison.OrdinalIgnoreCase))
             {
-                abs = Path.GetFullPath(Path.Combine(GGPaths.ProjectRoot, norm.TrimStart('/')));
+                abs = Path.GetFullPath(Path.Combine(ProjectRoot, norm.TrimStart('/')));
             }
             else
             {
-                abs = GGPaths.Data(norm);
+                abs = Path.GetFullPath(Path.Combine(dataRoot, norm));
             }
 
             var json = File.ReadAllText(abs);
@@ -49,3 +60,4 @@ namespace GG.Bridge.Validation
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- compute project root and data folder paths directly in DataIO
- load JSON from absolute, data-prefixed, or relative paths with internal logging

## Testing
- `mcs Assets/Scripts/Bridge/Validation/DataIO.cs` *(fails: Newtonsoft and GG.Infra references missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a011f9ae2c832795bcd636e31af69a