### PR TITLE
Use TeamProvider for dashboard team list

### DIFF
--- a/Assets/Scripts/UI/Dashboard/DashboardSceneController.cs
+++ b/Assets/Scripts/UI/Dashboard/DashboardSceneController.cs
@@ -27,7 +27,7 @@ namespace GG.UI.Dashboard
 
         void Awake()
         {
-            var abbrs = TeamDirectory.GetAbbrs();
+            var abbrs = new TeamProvider().GetAllTeamAbbrs();
             if (string.IsNullOrEmpty(selectedTeamAbbr)) selectedTeamAbbr = abbrs.Count > 0 ? abbrs[0] : "ATL";
             if (headerTeam) headerTeam.text = selectedTeamAbbr;
 


### PR DESCRIPTION
## Summary
- fix DashboardSceneController to retrieve team abbreviations using TeamProvider

## Testing
- `dotnet test` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a01a824a188327b3866010174084ff