### PR TITLE
Fix TMP text creation and refresh schedule on load

### DIFF
--- a/Assets/Scripts/UI/Cap/ContractDetailPanel.cs
+++ b/Assets/Scripts/UI/Cap/ContractDetailPanel.cs
@@ -13,7 +13,7 @@ public class ContractDetailPanel : MonoBehaviour
 
     void OnEnable()
     {
-        if (!content) content = gameObject.GetComponent<TMP_Text>() ?? gameObject.AddComponent<TMP_Text>();
+        if (!content) content = gameObject.GetComponent<TMP_Text>() ?? gameObject.AddComponent<TextMeshProUGUI>();
         Render();
     }
 
@@ -40,7 +40,7 @@ public class ContractDetailPanel : MonoBehaviour
         {
             var go = new GameObject("ErrorBanner", typeof(RectTransform));
             go.transform.SetParent(transform, false);
-            errorBanner = go.AddComponent<TMP_Text>();
+            errorBanner = go.AddComponent<TextMeshProUGUI>();
         }
         errorBanner.text = msg;
     }

--- a/Assets/Scripts/UI/Cap/ContractSmokePanel.cs
+++ b/Assets/Scripts/UI/Cap/ContractSmokePanel.cs
@@ -1,7 +1,6 @@
+using System.IO;
 using TMPro;
 using UnityEngine;
-using Newtonsoft.Json;
-using System.IO;
 using GG.Bridge.Dto;
 using GG.Bridge.Validation;
 
@@ -9,8 +8,8 @@ namespace GG.UI.Cap
 {
     public class ContractSmokePanel : MonoBehaviour
     {
-        public TMP_Text content;
-        public string RelativePath = "contracts/sample.json"; // under /data
+        [SerializeField] TMP_Text content;
+        [SerializeField] string RelativePath = "contracts/sample.json"; // under save path
 
         void OnEnable()
         {
@@ -18,7 +17,7 @@ namespace GG.UI.Cap
             {
                 var go = new GameObject("ContractSmoke", typeof(RectTransform));
                 go.transform.SetParent(transform, false);
-                content = go.AddComponent<TMP_Text>();
+                content = go.AddComponent<TextMeshProUGUI>();
             }
 
             EnsureSampleExists();
@@ -27,7 +26,7 @@ namespace GG.UI.Cap
 
         void EnsureSampleExists()
         {
-            var abs = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "data", RelativePath));
+            var abs = GGPaths.Save(RelativePath);
             var dir = Path.GetDirectoryName(abs);
             if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
 
@@ -37,32 +36,27 @@ namespace GG.UI.Cap
             {
                 ApiVersion = "gg.v1",
                 StartYear = 2026,
-                EndYear   = 2029,
+                EndYear = 2029,
                 Terms = new System.Collections.Generic.List<ContractYearTerm>
                 {
-                    new ContractYearTerm {
-                        Year = 2026, Base = 5_000_000, SigningProrated = 5_000_000,
-                        RosterBonus = 0, WorkoutBonus = 0, GuaranteedBase = 5_000_000
-                    },
-                    new ContractYearTerm {
-                        Year = 2027, Base = 6_000_000, SigningProrated = 5_000_000,
-                        RosterBonus = 0, WorkoutBonus = 0, GuaranteedBase = 3_000_000
-                    }
+                    new ContractYearTerm { Year = 2026, Base = 5_000_000, SigningProrated = 5_000_000, RosterBonus = 0, WorkoutBonus = 0, GuaranteedBase = 5_000_000 },
+                    new ContractYearTerm { Year = 2027, Base = 6_000_000, SigningProrated = 5_000_000, RosterBonus = 0, WorkoutBonus = 0, GuaranteedBase = 3_000_000 }
                 }
             };
 
-            var json = JsonConvert.SerializeObject(dto, Formatting.Indented);
+            var json = JsonUtility.ToJson(dto, true);
             File.WriteAllText(abs, json);
         }
 
         void ValidateAndShow()
         {
-            var abs  = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "data", RelativePath));
+            var abs = GGPaths.Save(RelativePath);
             var json = File.ReadAllText(abs);
-            var dto  = JsonConvert.DeserializeObject<ContractDTO>(json);
+            var dto = JsonUtility.FromJson<ContractDTO>(json);
 
             try { ContractValidator.Validate(dto); content.text = "Contract OK (gg.v1)"; }
             catch (GGDataException ex) { content.text = $"Contract invalid: {ex.Code}"; }
         }
     }
 }
+

--- a/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -41,7 +41,7 @@ namespace GG.UI.Cap
             {
                 var go = new GameObject("CapText", typeof(RectTransform));
                 go.transform.SetParent(transform, false);
-                content = go.AddComponent<TMP_Text>();
+                content = go.AddComponent<TextMeshProUGUI>();
             }
             Render();
         }

--- a/Assets/Scripts/UI/Schedule/TeamSchedulePanel.cs
+++ b/Assets/Scripts/UI/Schedule/TeamSchedulePanel.cs
@@ -8,8 +8,8 @@ namespace GG.UI.Schedule
 {
     public class TeamSchedulePanel : MonoBehaviour
     {
-        public TMP_Text content;
-        public string TeamAbbr = "ATL";
+        [SerializeField] TMP_Text content;
+        [SerializeField] string TeamAbbr = "ATL";
 
         void OnEnable()
         {
@@ -17,13 +17,15 @@ namespace GG.UI.Schedule
             {
                 var go = new GameObject("TeamScheduleText", typeof(RectTransform));
                 go.transform.SetParent(transform, false);
-                content = go.AddComponent<TMP_Text>();
+                var t = go.AddComponent<TextMeshProUGUI>();
+                t.enableWordWrapping = false;
+                t.fontSize = 18;
+                content = t;
             }
             RefreshTeamSchedule();
         }
 
-        // Called by DashboardSceneController after sims
-        void RefreshTeamSchedule()
+        public void RefreshTeamSchedule()
         {
             if (ScheduleRepository.Current == null) { content.text = "No schedule."; return; }
             var sb = new StringBuilder();
@@ -41,3 +43,4 @@ namespace GG.UI.Schedule
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- use TextMeshProUGUI for runtime-created HUD and panels
- refresh team schedule after schedule load or generation
- leverage TeamProvider and GGPaths in UI panels

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0202395f4832790418cc6c7486fcd