### PR TITLE
Refactor ContractSmokePanel to in-memory validation

### DIFF
--- a/Assets/Scripts/UI/Cap/ContractSmokePanel.cs
+++ b/Assets/Scripts/UI/Cap/ContractSmokePanel.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using GG.Bridge.Dto;
@@ -9,7 +9,8 @@ namespace GG.UI.Cap
     public class ContractSmokePanel : MonoBehaviour
     {
         [SerializeField] TMP_Text content;
-        [SerializeField, UnityEngine.Serialization.FormerlySerializedAs("RelativePath")] string relativePath = "sample.json"; // under /data/contracts/
+        [SerializeField, UnityEngine.Serialization.FormerlySerializedAs("RelativePath"), HideInInspector]
+        string _legacyRelativePath;
 
         void OnEnable()
         {
@@ -20,49 +21,20 @@ namespace GG.UI.Cap
                 content = go.AddComponent<TextMeshProUGUI>();
             }
 
-            EnsureSampleExists();
-            ValidateAndShow();
-        }
-
-        void EnsureSampleExists()
-        {
-            var abs = GGPaths.ContractFile(relativePath);
-            if (File.Exists(abs)) return;
-
             var dto = new ContractDTO
             {
                 ApiVersion = "gg.v1",
                 StartYear = 2026,
-                EndYear = 2029,
-                Terms = new System.Collections.Generic.List<ContractYearTerm>
+                EndYear = 2027,
+                Terms = new List<ContractYearTerm>
                 {
                     new ContractYearTerm { Year = 2026, Base = 5_000_000, SigningProrated = 5_000_000, RosterBonus = 0, WorkoutBonus = 0, GuaranteedBase = 5_000_000 },
                     new ContractYearTerm { Year = 2027, Base = 6_000_000, SigningProrated = 5_000_000, RosterBonus = 0, WorkoutBonus = 0, GuaranteedBase = 3_000_000 }
                 }
             };
-            var json = JsonUtility.ToJson(dto, true);
-            File.WriteAllText(abs, json);
-            GGLog.Info($"ContractSmokePanel: wrote sample to {abs}");
-        }
 
-        void ValidateAndShow()
-        {
-            var abs = GGPaths.ContractFile(relativePath);
-            var json = File.ReadAllText(abs);
-            var dto = JsonUtility.FromJson<ContractDTO>(json);
-
-            try
-            {
-                ContractValidator.Validate(dto);
-                content.text = "Contract OK (gg.v1)";
-                GGLog.Info("ContractSmokePanel: contract valid.");
-            }
-            catch (GGDataException ex)
-            {
-                content.text = $"Contract invalid: {ex.Code}";
-                GGLog.Warn($"ContractSmokePanel: contract invalid ({ex.Code}).");
-            }
+            try { ContractValidator.Validate(dto); content.text = "Contract OK (gg.v1)"; }
+            catch (GGDataException ex) { content.text = $"Contract invalid: {ex.Code}"; }
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- Simplify ContractSmokePanel to build and validate a sample contract entirely in-memory, removing GGPaths and IO dependencies while preserving legacy serialized field

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f2eeadb0832786a6a4cde303204b