### PR TITLE
chore: remove infra namespace from team cap view

### DIFF
--- a/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
-using GG.Infra;
 using GG.Bridge.Validation;
 
 namespace GG.UI.Cap


### PR DESCRIPTION
## Summary
- drop unused `GG.Infra` using from TeamCapView
- rely on global GGLog for cap sheet load errors

## Testing
- `mcs Assets/Scripts/UI/Cap/TeamCapView.cs -target:library` *(fails: command not found, installed mono)*
- `dotnet /usr/lib/dotnet/sdk/8.0.119/Roslyn/bincore/csc.dll /tmp/UnityStubs.cs Assets/Scripts/UI/Cap/TeamCapView.cs -target:library` *(fails: missing `System` namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a106642de08327909e157a8d3daf3f