### PR TITLE
Implement core path and team provider utilities

### DIFF
--- a/Assets/Editor/PrefabTools.cs
+++ b/Assets/Editor/PrefabTools.cs
@@ -1,23 +1,39 @@
 #if UNITY_EDITOR
-using UnityEditor; using UnityEngine; using System.IO;
-public static class PrefabTools {
-  [MenuItem("GridironGM/Dev/Scan & Remove Missing Scripts")]
-  public static void RemoveMissing() {
-    var guids = AssetDatabase.FindAssets("t:Prefab");
-    int removed=0, scanned=0;
-    foreach (var g in guids) {
-      var path = AssetDatabase.GUIDToAssetPath(g);
-      var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path); if (!prefab) continue;
-      scanned++; removed += GameObjectUtility.RemoveMonoBehavioursWithMissingScript(prefab);
-    }
-    Debug.Log($"[GG] Prefabs scanned:{scanned}, missing scripts removed:{removed}");
-  }
+using System.IO;
+using UnityEditor;
+using UnityEngine;
 
-  [MenuItem("GridironGM/Dev/Clear Season Save")]
-  public static void ClearSeason() {
-    var p = Path.Combine(Application.persistentDataPath, GGConventions.SeasonSaveFile);
-    if (File.Exists(p)) { File.Delete(p); Debug.Log($"[GG] Deleted {p}"); }
-    else Debug.Log("[GG] No season save found.");
-  }
+public static class PrefabTools
+{
+    [MenuItem("GridironGM/Dev/Scan & Remove Missing Scripts")]
+    public static void RemoveMissing()
+    {
+        var guids = AssetDatabase.FindAssets("t:Prefab");
+        int removed = 0, scanned = 0;
+        foreach (var g in guids)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(g);
+            var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            if (!prefab) continue;
+            scanned++;
+            removed += GameObjectUtility.RemoveMonoBehavioursWithMissingScript(prefab);
+        }
+        GGLog.Info($"Prefabs scanned:{scanned}, missing scripts removed:{removed}");
+    }
+
+    [MenuItem("GridironGM/Dev/Clear Season Save")]
+    public static void ClearSeason()
+    {
+        var p = GGPaths.Save(GGConventions.SeasonSaveFile);
+        if (File.Exists(p))
+        {
+            File.Delete(p);
+            GGLog.Info($"Deleted {p}");
+        }
+        else
+        {
+            GGLog.Info("No season save found.");
+        }
+    }
 }
 #endif

--- a/Assets/Scripts/Core/GGPaths.cs
+++ b/Assets/Scripts/Core/GGPaths.cs
@@ -20,6 +20,19 @@ public static class GGPaths
         return abs;
     }
 
+    public static string Streaming(string relative)
+    {
+        return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, relative.TrimStart('/', '\\')));
+    }
+
+    public static string Save(string relative)
+    {
+        var abs = Path.GetFullPath(Path.Combine(Application.persistentDataPath, relative.TrimStart('/', '\\')));
+        var dir = Path.GetDirectoryName(abs);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+        return abs;
+    }
+
     public static string ScheduleFile()           => Data("schedule.json");
     public static string ContractFile(string rel) => Data(Path.Combine("contracts", rel));
     public static string CapSheetFile(int year)   => Data(Path.Combine("cap", $"capsheet_{year}.json"));


### PR DESCRIPTION
## Summary
- add GGPaths.Streaming and GGPaths.Save helpers
- replace TeamProvider with ITeamProvider implementation using GGPaths/GGLog
- wire PrefabTools to new GGPaths and GGLog

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10a4f31bc8327aa86f1fb1e9cd513