### PR TITLE
Add GG.Infra compatibility shim and update DataIO

### DIFF
--- a/Assets/Scripts/Bridge/Validation/DataIO.cs
+++ b/Assets/Scripts/Bridge/Validation/DataIO.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
+using Paths = GG.Infra.GGPaths;
+using Log   = GG.Infra.GGLog;
 
 namespace GG.Bridge.Validation
 {
@@ -26,7 +28,7 @@ namespace GG.Bridge.Validation
         {
             if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Empty path", nameof(path));
 
-            var abs = Path.IsPathRooted(path) ? path : GGPaths.Data(path);
+            var abs = Path.IsPathRooted(path) ? path : Paths.Data(path);
 
             try
             {
@@ -55,12 +57,12 @@ namespace GG.Bridge.Validation
                     obj = JsonUtility.FromJson<T>(json);
                 }
 
-                GGLog.Info($"Loaded JSON: {abs}");
+                Log.Info($"Loaded JSON: {abs}");
                 return obj;
             }
             catch (Exception ex)
             {
-                GGLog.Error($"Failed to load JSON: {abs}", ex);
+                Log.Error($"Failed to load JSON: {abs}", ex);
                 throw;
             }
         }

--- a/Assets/Scripts/InfraCompat.cs
+++ b/Assets/Scripts/InfraCompat.cs
@@ -1,0 +1,28 @@
+// Single compatibility shim so legacy `using GG.Infra;` works.
+// Forwards to the global helpers defined without namespaces.
+namespace GG.Infra
+{
+    public static class GGPaths
+    {
+        public static string ProjectRoot => global::GGPaths.ProjectRoot;
+        public static string DataRoot() => global::GGPaths.DataRoot();
+        public static string Data(string relative) => global::GGPaths.Data(relative);
+        public static string ScheduleFile() => global::GGPaths.ScheduleFile();
+        public static string ContractFile(string rel) => global::GGPaths.ContractFile(rel);
+        public static string CapSheetFile(int year) => global::GGPaths.CapSheetFile(year);
+    }
+
+    public static class GGLog
+    {
+        public static void Info(string msg)  => global::GGLog.Info(msg);
+        public static void Warn(string msg)  => global::GGLog.Warn(msg);
+        public static void Error(string msg, System.Exception ex = null)
+            => global::GGLog.Error(msg, ex);
+    }
+
+    public static class TeamProvider
+    {
+        public static System.Collections.Generic.List<string> GetAbbrs()
+            => new global::TeamProvider().GetAllTeamAbbrs();
+    }
+}

--- a/Assets/Scripts/InfraCompat.cs.meta
+++ b/Assets/Scripts/InfraCompat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e30c8341d8064df2880e9d3c3b608847
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add InfraCompat shim forwarding GGPaths, GGLog, and TeamProvider to global helpers
- refactor DataIO to import the shim via aliases

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a10babce648327a5300b2e44e8de34