### PR TITLE
Use TextMeshProUGUI and extend InfraCompat

### DIFF
--- a/Assets/Scripts/InfraCompat.cs
+++ b/Assets/Scripts/InfraCompat.cs
@@ -7,6 +7,8 @@ namespace GG.Infra
         public static string ProjectRoot => global::GGPaths.ProjectRoot;
         public static string DataRoot() => global::GGPaths.DataRoot();
         public static string Data(string relative) => global::GGPaths.Data(relative);
+        public static string Streaming(string relative) => global::GGPaths.Streaming(relative);
+        public static string Save(string relative) => global::GGPaths.Save(relative);
         public static string ScheduleFile() => global::GGPaths.ScheduleFile();
         public static string ContractFile(string rel) => global::GGPaths.ContractFile(rel);
         public static string CapSheetFile(int year) => global::GGPaths.CapSheetFile(year);

--- a/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -42,6 +42,10 @@ namespace GG.UI.Cap
                 go.transform.SetParent(transform, false);
                 content = go.AddComponent<TextMeshProUGUI>();
             }
+
+            // Ensure wrapping mode is compatible with TMP 4.x
+            content.textWrappingMode = TextWrappingModes.NoWrap;
+
             Render();
         }
 

--- a/Assets/Scripts/UI/Dashboard/DepthChartPanel.cs
+++ b/Assets/Scripts/UI/Dashboard/DepthChartPanel.cs
@@ -23,6 +23,7 @@ namespace GridironGM.UI.Dashboard
             if (placeholder != null)
             {
                 placeholder.gameObject.SetActive(true);
+                placeholder.textWrappingMode = TextWrappingModes.NoWrap;
                 placeholder.text = $"Depth chart for {abbr} coming soon.";
             }
         }


### PR DESCRIPTION
## Summary
- Forward `GG.Infra.GGPaths` to include `Streaming` and `Save`
- Use `TextMeshProUGUI` with explicit wrapping in Cap view
- Set placeholder wrapping for depth chart panel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10f40d7d88327ae1aaad4e996c5cf