### PR TITLE
Restore core utilities and add file safety checks

### DIFF
--- a/Assets/Scripts/Bridge/Validation/DataIO.cs
+++ b/Assets/Scripts/Bridge/Validation/DataIO.cs
@@ -26,9 +26,19 @@ namespace GG.Bridge.Validation
         /// </summary>
         public static T LoadJson<T>(string path)
         {
-            if (string.IsNullOrWhiteSpace(path)) throw new ArgumentException("Empty path", nameof(path));
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                Log.Warn("LoadJson called with empty path");
+                return default;
+            }
 
             var abs = Path.IsPathRooted(path) ? path : Paths.Data(path);
+
+            if (!File.Exists(abs))
+            {
+                Log.Warn($"JSON file not found: {abs}");
+                return default;
+            }
 
             try
             {
@@ -62,8 +72,8 @@ namespace GG.Bridge.Validation
             }
             catch (Exception ex)
             {
-                Log.Error($"Failed to load JSON: {abs}", ex);
-                throw;
+                Log.Warn($"Failed to load JSON: {abs} ({ex.Message})");
+                return default;
             }
         }
     }

--- a/Assets/Scripts/Core/GGLog.cs
+++ b/Assets/Scripts/Core/GGLog.cs
@@ -2,8 +2,16 @@ using UnityEngine;
 
 public static class GGLog
 {
-    public static void Info(string msg)  => Debug.Log(msg);
-    public static void Warn(string msg)  => Debug.LogWarning(msg);
-    public static void Error(string msg, System.Exception ex = null)
-        => Debug.LogError(ex == null ? msg : $"{msg}\n{ex}");
+    public static void Log(string message) => Debug.Log(message);
+    public static void Log(object message) => Debug.Log(message);
+
+    public static void Info(string message) => Debug.Log(message);
+    public static void Info(object message) => Debug.Log(message);
+
+    public static void Warn(string message) => Debug.LogWarning(message);
+    public static void Warn(object message) => Debug.LogWarning(message);
+
+    public static void Error(string message) => Debug.LogError(message);
+    public static void Error(object message) => Debug.LogError(message);
+    public static void Error(string message, System.Exception ex) => Debug.LogError(ex == null ? message : message + "\n" + ex);
 }

--- a/Assets/Scripts/Core/GGPaths.cs
+++ b/Assets/Scripts/Core/GGPaths.cs
@@ -5,16 +5,28 @@ public static class GGPaths
 {
     public static string ProjectRoot => Path.GetFullPath(Path.Combine(Application.dataPath, ".."));
 
-    public static string DataRoot()
+    public static string DataRoot
     {
-        var p = Path.Combine(ProjectRoot, "data");
-        if (!Directory.Exists(p)) Directory.CreateDirectory(p);
-        return p;
+        get
+        {
+            var path = Path.Combine(Application.persistentDataPath, "GGData");
+            if (!Directory.Exists(path)) Directory.CreateDirectory(path);
+            return path;
+        }
     }
+
+    public static string StreamingRoot => Application.streamingAssetsPath;
+
+    public static string Json(string fileName) => Path.Combine(DataRoot, fileName);
+    public static string Config(string fileName) => Path.Combine(StreamingRoot, fileName);
+
+    public const string TeamsJson = "teams.json";
+    public const string RostersByTeamJson = "rosters_by_team.json";
+    public const string ScheduleJson = "schedule.json";
 
     public static string Data(string relative)
     {
-        var abs = Path.GetFullPath(Path.Combine(DataRoot(), relative.TrimStart('/', '\\')));
+        var abs = Path.GetFullPath(Path.Combine(DataRoot, relative.TrimStart('/', '\\')));
         var dir = Path.GetDirectoryName(abs);
         if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
         return abs;
@@ -22,7 +34,7 @@ public static class GGPaths
 
     public static string Streaming(string relative)
     {
-        return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, relative.TrimStart('/', '\\')));
+        return Path.GetFullPath(Path.Combine(StreamingRoot, relative.TrimStart('/', '\\')));
     }
 
     public static string Save(string relative)
@@ -33,7 +45,7 @@ public static class GGPaths
         return abs;
     }
 
-    public static string ScheduleFile()           => Data("schedule.json");
+    public static string ScheduleFile() => Data("schedule.json");
     public static string ContractFile(string rel) => Data(Path.Combine("contracts", rel));
-    public static string CapSheetFile(int year)   => Data(Path.Combine("cap", $"capsheet_{year}.json"));
+    public static string CapSheetFile(int year) => Data(Path.Combine("cap", $"capsheet_{year}.json"));
 }

--- a/Assets/Scripts/Core/TeamProvider.cs
+++ b/Assets/Scripts/Core/TeamProvider.cs
@@ -10,6 +10,15 @@ public interface ITeamProvider
 
 public class TeamProvider : ITeamProvider
 {
+    public static string SelectedAbbr
+    {
+        get => PlayerPrefs.GetString(GGConventions.SelectedTeamKey, string.Empty);
+        set { PlayerPrefs.SetString(GGConventions.SelectedTeamKey, value); PlayerPrefs.Save(); }
+    }
+
+    public static string GetSelectedTeamAbbreviation() => SelectedAbbr;
+    public static void SetSelectedTeamAbbreviation(string abbr) => SelectedAbbr = abbr;
+
     [Serializable] private class Team { public string abbreviation; }
     [Serializable] private class Root { public Team[] teams; }
 

--- a/Assets/Scripts/InfraCompat.cs
+++ b/Assets/Scripts/InfraCompat.cs
@@ -5,13 +5,19 @@ namespace GG.Infra
     public static class GGPaths
     {
         public static string ProjectRoot => global::GGPaths.ProjectRoot;
-        public static string DataRoot() => global::GGPaths.DataRoot();
+        public static string DataRoot => global::GGPaths.DataRoot;
+        public static string StreamingRoot => global::GGPaths.StreamingRoot;
+        public static string Json(string fileName) => global::GGPaths.Json(fileName);
+        public static string Config(string fileName) => global::GGPaths.Config(fileName);
         public static string Data(string relative) => global::GGPaths.Data(relative);
         public static string Streaming(string relative) => global::GGPaths.Streaming(relative);
         public static string Save(string relative) => global::GGPaths.Save(relative);
         public static string ScheduleFile() => global::GGPaths.ScheduleFile();
         public static string ContractFile(string rel) => global::GGPaths.ContractFile(rel);
         public static string CapSheetFile(int year) => global::GGPaths.CapSheetFile(year);
+        public const string TeamsJson = global::GGPaths.TeamsJson;
+        public const string RostersByTeamJson = global::GGPaths.RostersByTeamJson;
+        public const string ScheduleJson = global::GGPaths.ScheduleJson;
     }
 
     public static class GGLog

--- a/Assets/Scripts/UI/Cap/TeamCapView.cs
+++ b/Assets/Scripts/UI/Cap/TeamCapView.cs
@@ -56,6 +56,12 @@ namespace GG.UI.Cap
                 // Support either "cap/capsheet_YYYY.json" or "/data/cap/capsheet_YYYY.json"
                 var relative = $"cap/capsheet_{Year}.json";
                 var sheet = DataIO.LoadJson<CapSheet>(relative);
+                if (sheet == null || sheet.Rows == null)
+                {
+                    GGLog.Warn($"Cap sheet missing: {relative}");
+                    content.text = "Cap sheet not available.";
+                    return;
+                }
 
                 var list = new List<string>();
                 foreach (var r in sheet.Rows)


### PR DESCRIPTION
## Summary
- expand GGLog with object overloads and log method
- extend GGPaths with persistent data root and helper constants
- add selected team persistence to TeamProvider
- harden JSON loading and cap view against missing files

## Testing
- `xbuild "Gridiron GM Alpha Build/Assembly-CSharp.csproj"` *(fails: default XML namespace of the project must be the MSBuild XML namespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a266226f1083279925ae220214e916