### PR TITLE
Implement cleanup utility and dashboard tabs

### DIFF
--- a/Assets/Editor/GGTools.meta
+++ b/Assets/Editor/GGTools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d5d7b4c021af4e48bdbb4c39ba2b805d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/GGTools/CleanupMissingScripts.cs
+++ b/Assets/Editor/GGTools/CleanupMissingScripts.cs
@@ -1,0 +1,43 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public static class GGCleanupTools
+{
+    [MenuItem("Tools/GG/Cleanup Missing Scripts In Scene")]
+    public static void CleanupMissingInOpenScenes()
+    {
+        int total = 0;
+        for (int s = 0; s < SceneManager.sceneCount; s++)
+        {
+            var scene = SceneManager.GetSceneAt(s);
+            foreach (var root in scene.GetRootGameObjects())
+            {
+                total += GameObjectUtility.RemoveMonoBehavioursWithMissingScript(root);
+            }
+            EditorSceneManager.MarkSceneDirty(scene);
+        }
+        GGLog.Info($"[GGCleanup] Removed {total} missing script components from open scene(s).");
+    }
+
+    [MenuItem("Tools/GG/Cleanup Missing Scripts In Project Prefabs")]
+    public static void CleanupMissingInPrefabs()
+    {
+        var guids = AssetDatabase.FindAssets("t:Prefab");
+        int total = 0;
+        for (int i = 0; i < guids.Length; i++)
+        {
+            var path = AssetDatabase.GUIDToAssetPath(guids[i]);
+            var go = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+            if (!go)
+            {
+                continue;
+            }
+            total += GameObjectUtility.RemoveMonoBehavioursWithMissingScript(go);
+            EditorUtility.SetDirty(go);
+        }
+        AssetDatabase.SaveAssets();
+        GGLog.Info($"[GGCleanup] Removed {total} missing script components from prefabs.");
+    }
+}

--- a/Assets/Editor/GGTools/CleanupMissingScripts.cs.meta
+++ b/Assets/Editor/GGTools/CleanupMissingScripts.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7c38bde095d4caab569c2ab43f5201e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/PrefabTools.cs
+++ b/Assets/Editor/PrefabTools.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using UnityEditor;
+
+public static class PrefabTools
+{
+    [MenuItem("Tools/GG/Scan Missing Scripts")]
+    public static void ScanMissingScripts()
+    {
+        GGCleanupTools.CleanupMissingInOpenScenes();
+        GGCleanupTools.CleanupMissingInPrefabs();
+    }
+
+    [MenuItem("Tools/GG/Clear Season Save")]
+    public static void ClearSeasonSave()
+    {
+        var path = GGPaths.Json(GGConventions.SeasonSaveFile);
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+            GGLog.Info($"Deleted season save at {path}");
+        }
+        else
+        {
+            GGLog.Warn($"No season save found at {path}");
+        }
+    }
+}

--- a/Assets/Scripts/Core/GGConventions.cs
+++ b/Assets/Scripts/Core/GGConventions.cs
@@ -1,0 +1,6 @@
+public static class GGConventions
+{
+    public const string SelectedTeamKey = "SelectedTeam";
+    public const string SeasonSaveFile = "season.save";
+    public const string TeamsJsonFile = "Teams.json";
+}

--- a/Assets/Scripts/Core/GGConventions.cs.meta
+++ b/Assets/Scripts/Core/GGConventions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efed935f70e245a5b4975b57f253b7bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Dashboard/DashboardBootstrap.cs
+++ b/Assets/Scripts/UI/Dashboard/DashboardBootstrap.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+[DefaultExecutionOrder(-600)]
+public class DashboardBootstrap : MonoBehaviour
+{
+    void Awake()
+    {
+        if (!UnityEngine.Object.FindFirstObjectByType<DashboardTabsController>(FindObjectsInactive.Include))
+        {
+            var root = GameObject.Find("Dashboard") ?? new GameObject("Dashboard");
+            root.AddComponent<DashboardTabsController>();
+        }
+    }
+}

--- a/Assets/Scripts/UI/Dashboard/DashboardBootstrap.cs.meta
+++ b/Assets/Scripts/UI/Dashboard/DashboardBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c98f82e5a95e4fe880e9e554c60252b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -600
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Dashboard/DashboardTabsController.cs
+++ b/Assets/Scripts/UI/Dashboard/DashboardTabsController.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+[DefaultExecutionOrder(-500)]
+public class DashboardTabsController : MonoBehaviour
+{
+    [Header("Optional: assign explicitly; else found by name")]
+    [SerializeField] private GameObject rosterPanel;
+    [SerializeField] private GameObject depthChartsPanel;
+    [SerializeField] private GameObject teamSchedulePanel;
+
+    [SerializeField] private Transform tabsRoot;
+
+    void Awake()
+    {
+        rosterPanel = rosterPanel ?? GameObject.Find("RosterPanel");
+        depthChartsPanel = depthChartsPanel ?? GameObject.Find("DepthChartsPanel");
+        teamSchedulePanel = teamSchedulePanel ?? GameObject.Find("TeamSchedulePanel");
+
+        SetActiveSafe(rosterPanel, true);
+        SetActiveSafe(depthChartsPanel, false);
+        SetActiveSafe(teamSchedulePanel, false);
+
+        var searchRoot = tabsRoot ? tabsRoot : transform;
+        var buttons = searchRoot.GetComponentsInChildren<Button>(true).ToList();
+        if (buttons.Count == 0)
+        {
+            buttons = UnityEngine.Object
+                .FindObjectsByType<Button>(FindObjectsInactive.Include, FindObjectsSortMode.None)
+                .ToList();
+        }
+
+        foreach (var btn in buttons)
+        {
+            string label = GetButtonLabel(btn).ToLowerInvariant().Replace(" ", "");
+            if (label.Contains("roster"))
+            {
+                btn.onClick.AddListener(() => Show(roster: true));
+            }
+            else if (label.Contains("depth"))
+            {
+                btn.onClick.AddListener(() => Show(depth: true));
+            }
+            else if (label.Contains("schedule"))
+            {
+                btn.onClick.AddListener(() => Show(schedule: true));
+            }
+        }
+    }
+
+    static string GetButtonLabel(Button b)
+    {
+        var tmp = b.GetComponentInChildren<TMP_Text>(true);
+        if (tmp) return tmp.text;
+        var uText = b.GetComponentInChildren<UnityEngine.UI.Text>(true);
+        if (uText) return uText.text;
+        return b.gameObject.name;
+    }
+
+    void Show(bool roster = false, bool depth = false, bool schedule = false)
+    {
+        SetActiveSafe(rosterPanel, roster);
+        SetActiveSafe(depthChartsPanel, depth);
+        SetActiveSafe(teamSchedulePanel, schedule);
+    }
+
+    static void SetActiveSafe(GameObject go, bool on)
+    {
+        if (go && go.activeSelf != on)
+        {
+            go.SetActive(on);
+        }
+    }
+}

--- a/Assets/Scripts/UI/Dashboard/DashboardTabsController.cs.meta
+++ b/Assets/Scripts/UI/Dashboard/DashboardTabsController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a52d5cc9c5b64bc3aa021e8b6fc3d5fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -500
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add GGCleanupTools editor menus to strip missing scripts from scenes and prefabs
- self-wiring DashboardTabsController plus bootstrapper
- add project conventions helpers and PrefabTools bridge

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a27edc114083278a758ad2e1bea2d6