### PR TITLE
Add save and streaming path helpers to GGPaths

### DIFF
--- a/Assets/Editor/PrefabTools.cs
+++ b/Assets/Editor/PrefabTools.cs
@@ -13,7 +13,7 @@ public static class PrefabTools
     [MenuItem("Tools/GG/Clear Season Save")]
     public static void ClearSeasonSave()
     {
-        var path = GGPaths.Json(GGConventions.SeasonSaveFile);
+        var path = GGPaths.Save(GGConventions.SeasonSaveFile);
         if (File.Exists(path))
         {
             File.Delete(path);

--- a/Assets/Scripts/Core/GGPaths.cs
+++ b/Assets/Scripts/Core/GGPaths.cs
@@ -1,15 +1,48 @@
 using System.IO;
 using UnityEngine;
-public static class GGPaths {
-    public static string DataRoot => Path.Combine(Application.persistentDataPath,"GGData");
+
+public static class GGPaths
+{
+    /// <summary>
+    /// Root folder for persistent GG data.
+    /// </summary>
+    public static string DataRoot => SaveRoot;
+
+    /// <summary>
+    /// Root folder for persistent GG data.
+    /// </summary>
+    public static string SaveRoot => Path.Combine(Application.persistentDataPath, "GGData");
+
+    /// <summary>
+    /// Root folder for streaming assets.
+    /// </summary>
     public static string StreamingRoot => Application.streamingAssetsPath;
-    public static string Json(string file)=>EnsureDirAndCombine(DataRoot,file);
-    public static string Config(string file)=>Path.Combine(StreamingRoot,file);
-    public static string TeamsJson => Path.Combine(StreamingRoot,"config/teams.json");
-    public static string RostersByTeamJson => Json("rosters_by_team.json");
-    public static string ScheduleJson => Json("schedule.json");
-    static string EnsureDirAndCombine(string dir,string file){
-        if(!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-        return Path.Combine(dir,file);
+
+    /// <summary>
+    /// Combine a file name with the persistent data root and ensure the directory exists.
+    /// </summary>
+    public static string Save(string file) => EnsureDirAndCombine(SaveRoot, file);
+
+    /// <summary>
+    /// Combine a file name with the streaming assets root.
+    /// </summary>
+    public static string Streaming(string file) => Path.Combine(StreamingRoot, file);
+
+    // Legacy helpers retained for backward compatibility
+    public static string Json(string file) => Save(file);
+    public static string Config(string file) => Streaming(file);
+
+    public static string TeamsJson => Streaming("config/teams.json");
+    public static string RostersByTeamJson => Save("rosters_by_team.json");
+    public static string ScheduleJson => Save("schedule.json");
+
+    static string EnsureDirAndCombine(string dir, string file)
+    {
+        if (!Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        return Path.Combine(dir, file);
     }
 }


### PR DESCRIPTION
## Summary
- add `Save` and `Streaming` helpers to `GGPaths`
- use new `GGPaths.Save` in `PrefabTools` for clearing season save file

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d42598088327876c872fc3664a38